### PR TITLE
feat: add tests for JSDoc comments

### DIFF
--- a/.github/workflows/gas-benchmarks.yml
+++ b/.github/workflows/gas-benchmarks.yml
@@ -35,6 +35,10 @@ jobs:
         run: pnpm run format
         working-directory: gas-benchmarks
 
+      - name: Test
+        run: pnpm run test
+        working-directory: gas-benchmarks
+
       - name: Benchmark
         run: pnpm run benchmark
         working-directory: gas-benchmarks

--- a/gas-benchmarks/eslint.config.js
+++ b/gas-benchmarks/eslint.config.js
@@ -99,7 +99,13 @@ export default defineConfig([
       "import/no-extraneous-dependencies": [
         "error",
         {
-          devDependencies: ["**/*.test.ts", "**/__benchmarks__/**", "**/tests/**", "**/__tests__/**"],
+          devDependencies: [
+            "**/*.test.ts",
+            "**/__benchmarks__/**",
+            "**/tests/**",
+            "**/__tests__/**",
+            "**/vitest.config.ts",
+          ],
         },
       ],
       "no-debugger": isProduction ? "error" : "off",

--- a/gas-benchmarks/package.json
+++ b/gas-benchmarks/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "benchmark": "tsx src/index.ts",
+    "test": "vitest run",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint --ext .ts .",
@@ -46,7 +47,8 @@
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.55.0"
+    "typescript-eslint": "^8.55.0",
+    "vitest": "^4.0.18"
   },
   "dependencies": {
     "dotenv": "^17.2.4",

--- a/gas-benchmarks/pnpm-lock.yaml
+++ b/gas-benchmarks/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       typescript-eslint:
         specifier: ^8.55.0
         version: 8.55.0(eslint@10.0.0)(typescript@5.9.3)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
   "@adraffy/ens-normalize@1.11.1":
@@ -390,6 +393,10 @@ packages:
       { integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ== }
     engines: { node: 20 || >=22 }
 
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      { integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og== }
+
   "@napi-rs/wasm-runtime@0.2.12":
     resolution:
       { integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ== }
@@ -414,6 +421,169 @@ packages:
       { integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA== }
     engines: { node: ^12.20.0 || ^14.18.0 || >=16.0.0 }
 
+  "@rollup/rollup-android-arm-eabi@4.57.1":
+    resolution:
+      { integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg== }
+    cpu: [arm]
+    os: [android]
+
+  "@rollup/rollup-android-arm64@4.57.1":
+    resolution:
+      { integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w== }
+    cpu: [arm64]
+    os: [android]
+
+  "@rollup/rollup-darwin-arm64@4.57.1":
+    resolution:
+      { integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg== }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rollup/rollup-darwin-x64@4.57.1":
+    resolution:
+      { integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w== }
+    cpu: [x64]
+    os: [darwin]
+
+  "@rollup/rollup-freebsd-arm64@4.57.1":
+    resolution:
+      { integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug== }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@rollup/rollup-freebsd-x64@4.57.1":
+    resolution:
+      { integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q== }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+    resolution:
+      { integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw== }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-arm-musleabihf@4.57.1":
+    resolution:
+      { integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw== }
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-arm64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g== }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-arm64-musl@4.57.1":
+    resolution:
+      { integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q== }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-loong64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA== }
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-loong64-musl@4.57.1":
+    resolution:
+      { integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw== }
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-ppc64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w== }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-ppc64-musl@4.57.1":
+    resolution:
+      { integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw== }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-riscv64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A== }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-riscv64-musl@4.57.1":
+    resolution:
+      { integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw== }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-linux-s390x-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg== }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-x64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg== }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rollup/rollup-linux-x64-musl@4.57.1":
+    resolution:
+      { integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw== }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@rollup/rollup-openbsd-x64@4.57.1":
+    resolution:
+      { integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw== }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@rollup/rollup-openharmony-arm64@4.57.1":
+    resolution:
+      { integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ== }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@rollup/rollup-win32-arm64-msvc@4.57.1":
+    resolution:
+      { integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ== }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rollup/rollup-win32-ia32-msvc@4.57.1":
+    resolution:
+      { integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew== }
+    cpu: [ia32]
+    os: [win32]
+
+  "@rollup/rollup-win32-x64-gnu@4.57.1":
+    resolution:
+      { integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ== }
+    cpu: [x64]
+    os: [win32]
+
+  "@rollup/rollup-win32-x64-msvc@4.57.1":
+    resolution:
+      { integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA== }
+    cpu: [x64]
+    os: [win32]
+
   "@rtsao/scc@1.1.0":
     resolution:
       { integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g== }
@@ -430,9 +600,21 @@ packages:
     resolution:
       { integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A== }
 
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      { integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w== }
+
   "@tybys/wasm-util@0.10.1":
     resolution:
       { integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg== }
+
+  "@types/chai@5.2.3":
+    resolution:
+      { integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA== }
+
+  "@types/deep-eql@4.0.2":
+    resolution:
+      { integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw== }
 
   "@types/esrecurse@4.3.1":
     resolution:
@@ -645,6 +827,42 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@vitest/expect@4.0.18":
+    resolution:
+      { integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ== }
+
+  "@vitest/mocker@4.0.18":
+    resolution:
+      { integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ== }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  "@vitest/pretty-format@4.0.18":
+    resolution:
+      { integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw== }
+
+  "@vitest/runner@4.0.18":
+    resolution:
+      { integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw== }
+
+  "@vitest/snapshot@4.0.18":
+    resolution:
+      { integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA== }
+
+  "@vitest/spy@4.0.18":
+    resolution:
+      { integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw== }
+
+  "@vitest/utils@4.0.18":
+    resolution:
+      { integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA== }
+
   abitype@1.2.3:
     resolution:
       { integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg== }
@@ -737,6 +955,11 @@ packages:
       { integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ== }
     engines: { node: ">= 0.4" }
 
+  assertion-error@2.0.1:
+    resolution:
+      { integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA== }
+    engines: { node: ">=12" }
+
   ast-types-flow@0.0.8:
     resolution:
       { integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ== }
@@ -797,6 +1020,11 @@ packages:
     resolution:
       { integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ== }
     engines: { node: ">=6" }
+
+  chai@6.2.2:
+    resolution:
+      { integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg== }
+    engines: { node: ">=18" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -929,6 +1157,10 @@ packages:
     resolution:
       { integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w== }
     engines: { node: ">= 0.4" }
+
+  es-module-lexer@1.7.0:
+    resolution:
+      { integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA== }
 
   es-object-atoms@1.1.1:
     resolution:
@@ -1155,6 +1387,10 @@ packages:
       { integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA== }
     engines: { node: ">=4.0" }
 
+  estree-walker@3.0.3:
+    resolution:
+      { integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g== }
+
   esutils@2.0.3:
     resolution:
       { integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g== }
@@ -1163,6 +1399,11 @@ packages:
   eventemitter3@5.0.1:
     resolution:
       { integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA== }
+
+  expect-type@1.3.0:
+    resolution:
+      { integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA== }
+    engines: { node: ">=12.0.0" }
 
   fast-deep-equal@3.1.3:
     resolution:
@@ -1593,6 +1834,10 @@ packages:
       { integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw== }
     engines: { node: ">=18" }
 
+  magic-string@0.30.21:
+    resolution:
+      { integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ== }
+
   math-intrinsics@1.1.0:
     resolution:
       { integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g== }
@@ -1634,6 +1879,12 @@ packages:
     resolution:
       { integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw== }
     engines: { node: ">=20.17" }
+
+  nanoid@3.3.11:
+    resolution:
+      { integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w== }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
 
   napi-postinstall@0.3.4:
     resolution:
@@ -1684,6 +1935,10 @@ packages:
     resolution:
       { integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA== }
     engines: { node: ">= 0.4" }
+
+  obug@2.1.1:
+    resolution:
+      { integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ== }
 
   onetime@7.0.0:
     resolution:
@@ -1738,6 +1993,14 @@ packages:
     resolution:
       { integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw== }
 
+  pathe@2.0.3:
+    resolution:
+      { integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w== }
+
+  picocolors@1.1.1:
+    resolution:
+      { integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA== }
+
   picomatch@2.3.1:
     resolution:
       { integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA== }
@@ -1758,6 +2021,11 @@ packages:
     resolution:
       { integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg== }
     engines: { node: ">= 0.4" }
+
+  postcss@8.5.6:
+    resolution:
+      { integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg== }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prelude-ls@1.2.1:
     resolution:
@@ -1826,6 +2094,12 @@ packages:
   rfdc@1.4.1:
     resolution:
       { integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA== }
+
+  rollup@4.57.1:
+    resolution:
+      { integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A== }
+    engines: { node: ">=18.0.0", npm: ">=8.0.0" }
+    hasBin: true
 
   safe-array-concat@1.1.3:
     resolution:
@@ -1898,6 +2172,10 @@ packages:
       { integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw== }
     engines: { node: ">= 0.4" }
 
+  siginfo@2.0.0:
+    resolution:
+      { integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g== }
+
   signal-exit@4.1.0:
     resolution:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
@@ -1908,10 +2186,23 @@ packages:
       { integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w== }
     engines: { node: ">=18" }
 
+  source-map-js@1.2.1:
+    resolution:
+      { integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA== }
+    engines: { node: ">=0.10.0" }
+
   stable-hash-x@0.2.0:
     resolution:
       { integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ== }
     engines: { node: ">=12.0.0" }
+
+  stackback@0.0.2:
+    resolution:
+      { integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw== }
+
+  std-env@3.10.0:
+    resolution:
+      { integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg== }
 
   steno@4.0.2:
     resolution:
@@ -1992,10 +2283,24 @@ packages:
       { integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ== }
     engines: { node: ^14.18.0 || >=16.0.0 }
 
+  tinybench@2.9.0:
+    resolution:
+      { integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg== }
+
+  tinyexec@1.0.2:
+    resolution:
+      { integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg== }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.15:
     resolution:
       { integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ== }
     engines: { node: ">=12.0.0" }
+
+  tinyrainbow@3.0.3:
+    resolution:
+      { integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q== }
+    engines: { node: ">=14.0.0" }
 
   to-regex-range@5.0.1:
     resolution:
@@ -2088,6 +2393,82 @@ packages:
       typescript:
         optional: true
 
+  vite@7.3.1:
+    resolution:
+      { integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA== }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^20.19.0 || >=22.12.0
+      jiti: ">=1.21.0"
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution:
+      { integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ== }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.0.18
+      "@vitest/browser-preview": 4.0.18
+      "@vitest/browser-webdriverio": 4.0.18
+      "@vitest/ui": 4.0.18
+      happy-dom: "*"
+      jsdom: "*"
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser-playwright":
+        optional: true
+      "@vitest/browser-preview":
+        optional: true
+      "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-json-languageservice@4.2.1:
     resolution:
       { integrity: sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA== }
@@ -2132,6 +2513,12 @@ packages:
     resolution:
       { integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA== }
     engines: { node: ">= 8" }
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution:
+      { integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w== }
+    engines: { node: ">=8" }
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2350,6 +2737,8 @@ snapshots:
     dependencies:
       "@isaacs/balanced-match": 4.0.1
 
+  "@jridgewell/sourcemap-codec@1.5.5": {}
+
   "@napi-rs/wasm-runtime@0.2.12":
     dependencies:
       "@emnapi/core": 1.8.1
@@ -2367,6 +2756,81 @@ snapshots:
 
   "@pkgr/core@0.2.9": {}
 
+  "@rollup/rollup-android-arm-eabi@4.57.1":
+    optional: true
+
+  "@rollup/rollup-android-arm64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-darwin-arm64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-darwin-x64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-freebsd-arm64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-freebsd-x64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-arm-gnueabihf@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-arm-musleabihf@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-arm64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-arm64-musl@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-loong64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-loong64-musl@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-ppc64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-ppc64-musl@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-riscv64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-riscv64-musl@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-s390x-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-x64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-linux-x64-musl@4.57.1":
+    optional: true
+
+  "@rollup/rollup-openbsd-x64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-openharmony-arm64@4.57.1":
+    optional: true
+
+  "@rollup/rollup-win32-arm64-msvc@4.57.1":
+    optional: true
+
+  "@rollup/rollup-win32-ia32-msvc@4.57.1":
+    optional: true
+
+  "@rollup/rollup-win32-x64-gnu@4.57.1":
+    optional: true
+
+  "@rollup/rollup-win32-x64-msvc@4.57.1":
+    optional: true
+
   "@rtsao/scc@1.1.0": {}
 
   "@scure/base@1.2.6": {}
@@ -2382,10 +2846,19 @@ snapshots:
       "@noble/hashes": 1.8.0
       "@scure/base": 1.2.6
 
+  "@standard-schema/spec@1.1.0": {}
+
   "@tybys/wasm-util@0.10.1":
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  "@types/chai@5.2.3":
+    dependencies:
+      "@types/deep-eql": 4.0.2
+      assertion-error: 2.0.1
+
+  "@types/deep-eql@4.0.2": {}
 
   "@types/esrecurse@4.3.1": {}
 
@@ -2549,6 +3022,45 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.11.1":
     optional: true
 
+  "@vitest/expect@4.0.18":
+    dependencies:
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.0.18
+      "@vitest/utils": 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  "@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2))":
+    dependencies:
+      "@vitest/spy": 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+
+  "@vitest/pretty-format@4.0.18":
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  "@vitest/runner@4.0.18":
+    dependencies:
+      "@vitest/utils": 4.0.18
+      pathe: 2.0.3
+
+  "@vitest/snapshot@4.0.18":
+    dependencies:
+      "@vitest/pretty-format": 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  "@vitest/spy@4.0.18": {}
+
+  "@vitest/utils@4.0.18":
+    dependencies:
+      "@vitest/pretty-format": 4.0.18
+      tinyrainbow: 3.0.3
+
   abitype@1.2.3(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
@@ -2645,6 +3157,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -2690,6 +3204,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -2853,6 +3369,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -3135,9 +3653,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      "@types/estree": 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3491,6 +4015,10 @@ snapshots:
     dependencies:
       steno: 4.0.2
 
+  magic-string@0.30.21:
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   micromatch@4.0.8:
@@ -3517,6 +4045,8 @@ snapshots:
   ms@2.1.3: {}
 
   nano-spawn@2.0.0: {}
+
+  nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3563,6 +4093,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  obug@2.1.1: {}
 
   onetime@7.0.0:
     dependencies:
@@ -3616,6 +4148,10 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
@@ -3623,6 +4159,12 @@ snapshots:
   pidtree@0.6.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -3684,6 +4226,37 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
+
+  rollup@4.57.1:
+    dependencies:
+      "@types/estree": 1.0.8
+    optionalDependencies:
+      "@rollup/rollup-android-arm-eabi": 4.57.1
+      "@rollup/rollup-android-arm64": 4.57.1
+      "@rollup/rollup-darwin-arm64": 4.57.1
+      "@rollup/rollup-darwin-x64": 4.57.1
+      "@rollup/rollup-freebsd-arm64": 4.57.1
+      "@rollup/rollup-freebsd-x64": 4.57.1
+      "@rollup/rollup-linux-arm-gnueabihf": 4.57.1
+      "@rollup/rollup-linux-arm-musleabihf": 4.57.1
+      "@rollup/rollup-linux-arm64-gnu": 4.57.1
+      "@rollup/rollup-linux-arm64-musl": 4.57.1
+      "@rollup/rollup-linux-loong64-gnu": 4.57.1
+      "@rollup/rollup-linux-loong64-musl": 4.57.1
+      "@rollup/rollup-linux-ppc64-gnu": 4.57.1
+      "@rollup/rollup-linux-ppc64-musl": 4.57.1
+      "@rollup/rollup-linux-riscv64-gnu": 4.57.1
+      "@rollup/rollup-linux-riscv64-musl": 4.57.1
+      "@rollup/rollup-linux-s390x-gnu": 4.57.1
+      "@rollup/rollup-linux-x64-gnu": 4.57.1
+      "@rollup/rollup-linux-x64-musl": 4.57.1
+      "@rollup/rollup-openbsd-x64": 4.57.1
+      "@rollup/rollup-openharmony-arm64": 4.57.1
+      "@rollup/rollup-win32-arm64-msvc": 4.57.1
+      "@rollup/rollup-win32-ia32-msvc": 4.57.1
+      "@rollup/rollup-win32-x64-gnu": 4.57.1
+      "@rollup/rollup-win32-x64-msvc": 4.57.1
+      fsevents: 2.3.3
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -3764,6 +4337,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@7.1.2:
@@ -3771,7 +4346,13 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  source-map-js@1.2.1: {}
+
   stable-hash-x@0.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   steno@4.0.2: {}
 
@@ -3857,10 +4438,16 @@ snapshots:
     dependencies:
       "@pkgr/core": 0.2.9
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -3991,6 +4578,57 @@ snapshots:
       - utf-8-validate
       - zod
 
+  vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      "@types/node": 25.2.3
+      fsevents: 2.3.3
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vitest@4.0.18(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      "@vitest/expect": 4.0.18
+      "@vitest/mocker": 4.0.18(vite@7.3.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2))
+      "@vitest/pretty-format": 4.0.18
+      "@vitest/runner": 4.0.18
+      "@vitest/snapshot": 4.0.18
+      "@vitest/spy": 4.0.18
+      "@vitest/utils": 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.2.3)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@types/node": 25.2.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vscode-json-languageservice@4.2.1:
     dependencies:
       jsonc-parser: 3.3.1
@@ -4051,6 +4689,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/gas-benchmarks/src/__tests__/constants.test.ts
+++ b/gas-benchmarks/src/__tests__/constants.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { resolve } from "node:path";
+
+import type { Entry } from "./types.js";
+
+import {
+  extractEtherscanUrls,
+  findProtocolConstantsFiles,
+  hasEtherscanExample,
+  hasSolUrl,
+  parseConstantsFile,
+} from "./utils.js";
+
+describe("constants.ts files", () => {
+  let files: Entry[] = [];
+
+  beforeAll(() => {
+    const srcDir = resolve(__dirname, "..");
+
+    const filePaths = findProtocolConstantsFiles(srcDir);
+
+    files = filePaths.map((filePath) => ({
+      filePath,
+      ...parseConstantsFile(filePath),
+    }));
+  });
+
+  it("should have at least one contract address", () => {
+    files.forEach(({ filePath, addresses }) => {
+      expect(
+        addresses.length,
+        `${filePath} must have at least one contract address (Hex-typed constant)`,
+      ).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("should have at least two events array", () => {
+    files.forEach(({ filePath, events }) => {
+      expect(
+        events.length,
+        `${filePath} must have at least two events arrays (array with parseAbiItem calls)`,
+      ).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("should have a URL to a .sol source file for each contract address", () => {
+    files.forEach(({ filePath, addresses }) => {
+      addresses.forEach(({ name, comment }) => {
+        expect(hasSolUrl(comment), `JSDoc for ${name} in ${filePath} must have a URL ending in .sol`).toBe(true);
+      });
+    });
+  });
+
+  it("should have a URL to a .sol source file for each events array indicating the function that emits the events", () => {
+    files.forEach(({ filePath, events }) => {
+      events.forEach(({ name, comment }) => {
+        expect(hasSolUrl(comment), `JSDoc for ${name} in ${filePath} must have a URL ending in .sol`).toBe(true);
+      });
+    });
+  });
+
+  it("should have a Emits: section describing all events for each events array", () => {
+    files.forEach(({ filePath, events }) => {
+      events.forEach(({ name, arrayEventCount, emitsEventCount }) => {
+        expect(
+          emitsEventCount,
+          `JSDoc for ${name} in ${filePath} must describe all ${arrayEventCount} event(s) in the Emits: section`,
+        ).toBe(arrayEventCount);
+      });
+    });
+  });
+
+  it("should have an Example: section with an etherscan transaction URL for each events array", () => {
+    files.forEach(({ filePath, events }) => {
+      events.forEach(({ name, comment }) => {
+        expect(
+          hasEtherscanExample(comment),
+          `JSDoc for ${name} in ${filePath} must contain an etherscan.io/tx/0x123... example URL`,
+        ).toBe(true);
+      });
+    });
+  });
+
+  it("should not repeat etherscan URL examples across events arrays", () => {
+    const allUrls: string[] = [];
+    const urlToLocations: Record<string, string[]> = {};
+
+    files.forEach(({ filePath, events }) => {
+      events.forEach(({ name, comment }) => {
+        const urls = extractEtherscanUrls(comment);
+        urls.forEach((url) => {
+          allUrls.push(url);
+          if (!urlToLocations[url]) {
+            urlToLocations[url] = [];
+          }
+          urlToLocations[url].push(`${filePath} (${name})`);
+        });
+      });
+    });
+
+    const duplicates = Object.entries(urlToLocations)
+      .filter(([, locations]) => locations.length > 1)
+      .map(([url, locations]) => `${url} found in: ${locations.join(", ")}`);
+
+    expect(
+      duplicates,
+      `Etherscan URLs must not be repeated across events arrays:\n${duplicates.join("\n")}`,
+    ).toHaveLength(0);
+  });
+});

--- a/gas-benchmarks/src/__tests__/types.ts
+++ b/gas-benchmarks/src/__tests__/types.ts
@@ -1,0 +1,19 @@
+export interface AddressEntry {
+  name: string;
+  comment: string;
+  file: string;
+}
+
+export interface EventsEntry {
+  name: string;
+  comment: string;
+  file: string;
+  arrayEventCount: number;
+  emitsEventCount: number;
+}
+
+export interface Entry {
+  addresses: AddressEntry[];
+  events: EventsEntry[];
+  filePath: string;
+}

--- a/gas-benchmarks/src/__tests__/utils.ts
+++ b/gas-benchmarks/src/__tests__/utils.ts
@@ -1,0 +1,94 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { AddressEntry, EventsEntry } from "./types.js";
+
+/**
+ * Recursively scan `srcDir` for `constants.ts` files, skipping excluded directories.
+ */
+export function findProtocolConstantsFiles(srcDir: string): string[] {
+  const EXCLUDED_DIRS = new Set(["__tests__", "utils"]);
+
+  const results: string[] = [];
+
+  function scan(dir: string): void {
+    readdirSync(dir, { withFileTypes: true }).forEach((entry) => {
+      const path = join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRS.has(entry.name)) {
+          scan(path);
+        }
+      } else if (entry.name === "constants.ts") {
+        results.push(path);
+      }
+    });
+  }
+
+  scan(srcDir);
+  return results;
+}
+
+/**
+ * Extract JSDoc comment + constant name pairs from a constants.ts source file.
+ * Returns Hex address constants and events array constants separately.
+ */
+export function parseConstantsFile(filePath: string): { addresses: AddressEntry[]; events: EventsEntry[] } {
+  const source = readFileSync(filePath, "utf-8");
+  const addresses: AddressEntry[] = [];
+  const events: EventsEntry[] = [];
+
+  // Match JSDoc block followed by a Hex-typed export const
+  const hexRegEx = /\/\*\*([\s\S]*?)\*\/\s*export const (\w+)\s*:\s*Hex\s*=/g;
+  let match = hexRegEx.exec(source);
+
+  while (match !== null) {
+    addresses.push({
+      comment: match[1] ?? "",
+      name: match[2] ?? "",
+      file: filePath,
+    });
+    match = hexRegEx.exec(source);
+  }
+
+  // Match JSDoc block followed by an events array export const (ends with `] as const`)
+  const eventsRegEx = /\/\*\*([\s\S]*?)\*\/\s*export const (\w+)\s*=\s*\[([\s\S]*?)\]\s*as const/g;
+  match = eventsRegEx.exec(source);
+
+  while (match !== null) {
+    const comment = match[1] ?? "";
+    const name = match[2] ?? "";
+    const arrayContent = match[3] ?? "";
+
+    // Count `parseAbiItem` calls in the array → number of events declared
+    const arrayEventCount = (arrayContent.match(/parseAbiItem\(/g) ?? []).length;
+
+    // Extract the Emits: section (between "Emits:" and "Example:" or end of comment)
+    const emitsSection = /Emits:([\s\S]*?)(?:Example:|$)/.exec(comment)?.[1] ?? "";
+
+    // Count lines of the form "* EventName() - description"
+    const emitsEventCount = (emitsSection.match(/\*\s+\w+\([^)]*\)\s*-/g) ?? []).length;
+
+    events.push({ name, comment, file: filePath, arrayEventCount, emitsEventCount });
+    match = eventsRegEx.exec(source);
+  }
+
+  return { addresses, events };
+}
+
+/** Checks that a JSDoc comment contains a URL whose path ends with `.sol`. */
+export function hasSolUrl(comment: string): boolean {
+  return /https?:\/\/\S+\.sol(?:#\S*)?(?=\s|$)/i.test(comment);
+}
+
+/** Extracts etherscan transaction URLs from a JSDoc comment. */
+export function extractEtherscanUrls(comment: string): string[] {
+  const etherscanTxUrlRegEx = /https:\/\/etherscan\.io\/tx\/0x[\da-fA-F]+/;
+  const matches = comment.match(new RegExp(etherscanTxUrlRegEx.source, "g"));
+  return matches ?? [];
+}
+
+/** Checks that a JSDoc comment contains an etherscan transaction example URL. */
+export function hasEtherscanExample(comment: string): boolean {
+  return extractEtherscanUrls(comment).length > 0;
+}

--- a/gas-benchmarks/vitest.config.ts
+++ b/gas-benchmarks/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Blocked by: https://github.com/privacy-ethereum/private-transfers-benchmarks/pull/17 .

Add tests for constants.ts files of all projects

- All contract addresses need to have one URL pointing to a .sol source code file
- All event arrays need to be documented with their event name and a brief description to understand better the execution pipeline
- All events need to have one URL pointing to a .sol source code file indicating the entrypoint function of the contract
- All events need to have one example URL pointing to a transaction in Etherscan


This will help the AI agents to propose cleaner PRs


**IMPORTANT:** I will squash commits after previous PR is merged