### PR TITLE
feat/add intmax

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# GitHub Copilot Instructions for Private Transfers Benchmarks
+
+> **Note:** These guidelines primarily apply to the `gas-benchmarks/` package but can serve as general standards for TypeScript code across the repository.
+
+## Benchmarks definitions
+- **Shield**: Converting public assets into private ones by depositing them into a privacy pool or protocol. (e.g. shield, bridge, encrypt, etc)
+- **Unshield**: Converting private assets back into public ones by withdrawing them from a privacy pool or protocol. (e.g. unshield, bridge, decrypt, etc)
+- **Transfer**: Moving private assets from one address to another within the privacy pool or protocol. (e.g. transfer, send, etc)
+
+## 1. Clean and Concise Code
+
+- Write clean, short code with minimal boilerplate
+- **Do NOT add third-party dependencies** unless strictly necessary (approved: `viem`, `lowdb`, `dotenv`)
+- Avoid premature abstractions. Only abstract when you have 2+ implementations or clear reuse cases
+- Maintain detailed JSDoc comments on constant exports with GitHub links, `Emits:` section, and `@example` URLs
+  - See `src/privacy-pools/constants.ts` or `src/railgun/constants.ts` for examples
+  - Validated by `src/__tests__/constants.test.ts`
+- Minimize inline comments - code should be self-explanatory
+- No `console.log` (prohibited by ESLint)
+
+## 2. Use examples and references in comments
+- You can use the URLs in the comments to fetch information about the contract (events, functions, etc.). This is useful for understanding context and debugging.
+
+## 3. Functional Programming Over Loops
+
+- **PREFER** `forEach()`, `map()`, `reduce()`, `filter()`, `every()`, `some()` over `for`/`while` loops
+- Use `Promise.all()` for parallel async operations
+- Exception: loops acceptable for complex control flow (see `src/utils/rpc.ts` pagination)
+- Examples: `src/utils/utils.ts`, `src/utils/rpc.ts`, `src/index.ts`
+
+## 4. Type Organization
+
+- **ALL** types/interfaces MUST be in dedicated `types.ts` files
+- **NEVER** define types inline in implementation files
+- Locations: `src/utils/types.ts` (shared), `src/__tests__/types.ts` (test-specific)
+- Use inline type imports: `import type { Type } from "./types.js";`
+
+## 5. Utility Function Organization
+
+- **ALL** reusable functions MUST be in dedicated utility files
+- **NEVER** define utilities inline with implementation code
+- Locations: `src/utils/utils.ts`, `src/utils/rpc.ts`, `src/utils/db.ts`, `src/__tests__/utils.ts`
+- Prefer pure functions that minimize side effects
+
+## 6. Clean Code Principles
+
+- Follow Clean Code guidelines, but rules 1-4 above take precedence if there's a conflict
+
+## 7. Testing Requirements
+
+- **ALWAYS** run `pnpm run test` and `pnpm run benchmark` after changes
+- Do NOT complete work without running these verification steps
+- Fix all test failures and benchmark errors before finalizing
+
+## Examples
+
+- Protocol patterns: `src/railgun/index.ts`, `src/tornado-cash/index.ts`, `src/privacy-pools/index.ts`
+- Protocol specific constants to interact with: `src/railgun/constants.ts`, `src/tornado-cash/constants.ts`, `src/privacy-pools/constants.ts`
+- Functional programming: `src/utils/utils.ts`, `src/utils/rpc.ts`, `src/index.ts`
+- Type organization: `src/utils/types.ts`, `src/__tests__/types.ts`

--- a/.github/workflows/gas-benchmarks.yml
+++ b/.github/workflows/gas-benchmarks.yml
@@ -44,4 +44,5 @@ jobs:
         working-directory: gas-benchmarks
         env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
+          SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
           NUMBER_OF_TRANSACTIONS: ${{ vars.NUMBER_OF_TRANSACTIONS }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@.github/copilot-instructions.md

--- a/gas-benchmarks/.env.example
+++ b/gas-benchmarks/.env.example
@@ -1,5 +1,7 @@
 ETH_RPC_URL=https://mainnet.gateway.tenderly.co
 
+SCROLL_RPC_URL=https://scroll.gateway.tenderly.co
+
 NUMBER_OF_TRANSACTIONS=100
 
 MAX_NUMBER_OF_RPC_TRIES=50

--- a/gas-benchmarks/src/__tests__/utils.ts
+++ b/gas-benchmarks/src/__tests__/utils.ts
@@ -83,8 +83,8 @@ export function hasSolUrl(comment: string): boolean {
 
 /** Extracts etherscan transaction URLs from a JSDoc comment. */
 export function extractEtherscanUrls(comment: string): string[] {
-  const etherscanTxUrlRegEx = /https:\/\/etherscan\.io\/tx\/0x[\da-fA-F]+/;
-  const matches = comment.match(new RegExp(etherscanTxUrlRegEx.source, "g"));
+  const blockExplorerTxUrlRegEx = /https:\/\/[a-z]+scan\.[a-z]+\/tx\/0x[\da-fA-F]+/;
+  const matches = comment.match(new RegExp(blockExplorerTxUrlRegEx.source, "g"));
   return matches ?? [];
 }
 

--- a/gas-benchmarks/src/index.ts
+++ b/gas-benchmarks/src/index.ts
@@ -1,3 +1,4 @@
+import { Intmax } from "./intmax/index.js";
 import { PrivacyPools } from "./privacy-pools/index.js";
 import { Railgun } from "./railgun/index.js";
 import { TornadoCash } from "./tornado-cash/index.js";
@@ -6,15 +7,17 @@ import { db } from "./utils/db.js";
 const railgun = new Railgun();
 const tornadoCash = new TornadoCash();
 const privacyPools = new PrivacyPools();
+const intmax = new Intmax();
 
 await db.read();
 
 const start = Date.now();
 
-const [railgunMetrics, tornadoCashMetrics, privacyPoolsMetrics] = await Promise.all([
+const [railgunMetrics, tornadoCashMetrics, privacyPoolsMetrics, intmaxMetrics] = await Promise.all([
   railgun.benchmark(),
   tornadoCash.benchmark(),
   privacyPools.benchmark(),
+  intmax.benchmark(),
 ]);
 
 await db.update((data) => {
@@ -35,6 +38,12 @@ await db.update((data) => {
   data[`${privacyPools.name}_${privacyPools.version}`] = {
     shield_eth: privacyPoolsMetrics.shieldEth,
     unshield_eth: privacyPoolsMetrics.unshieldEth,
+  };
+
+  // eslint-disable-next-line no-param-reassign
+  data[`${intmax.name}_${intmax.version}`] = {
+    deposit_eth: intmaxMetrics.depositEth,
+    withdraw_eth: intmaxMetrics.withdrawEth,
   };
 });
 

--- a/gas-benchmarks/src/intmax/constants.ts
+++ b/gas-benchmarks/src/intmax/constants.ts
@@ -1,0 +1,103 @@
+import { parseAbiItem, type Hex } from "viem";
+
+import { NUMBER_OF_TRANSACTIONS } from "../utils/constants.js";
+
+/**
+ * Maximum number of logs with a Deposited event to be searched.
+ * Depends on the ratio of how many AA txs - EOA txs
+ */
+export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 10;
+
+/**
+ * Intmax froze deposits so we will hit rate limit if we search logs from the latest block.
+ */
+export const DEPOSIT_ETH_FROM_BLOCK = 24402900n;
+
+/**
+ * INTMAX Liquidity contract on Ethereum mainnet that handles ETH native deposits and withdrawals:
+ * https://github.com/InternetMaximalism/intmax2-contract/blob/main/contracts/liquidity/Liquidity.sol
+ */
+export const INTMAX_LIQUIDITY_PROXY: Hex = "0xF65e73aAc9182e353600a916a6c7681F810f79C3";
+
+/**
+ * Liquidity.depositNativeToken function:
+ * https://github.com/InternetMaximalism/intmax2-contract/blob/83b00c76049a75ac5186661ee7ecb10d0ce6ec25/contracts/liquidity/Liquidity.sol#L269
+ *
+ * Emits:
+ * TaskValidated() - To notify AML permission (emitted by one of Predicate contracts.
+ * I couldn't find the specific event in the codebase. Intmax uses this package https://www.npmjs.com/package/@predicate/contracts)
+ * Deposited() - To notify the deposit to the INTMAX network (emitted by the Liquidity contract)
+ *
+ * Example:
+ * https://etherscan.io/tx/0x6de98a249147cb1b384add0a9e1770094728fffbe811f9909ba0c59c528e4d37
+ *
+ * NOTE: Intmax paused deposits and withdrawals due to a ZK bug on Feb 7th, 2026. There are a lot of reverted txs since then
+ * Reference: https://x.com/intmaxIO/status/2020114765171855805
+ */
+export const DEPOSIT_ETH_EVENTS = [
+  parseAbiItem(
+    "event TaskValidated(address indexed msgSender, address indexed target, uint256 indexed value, string policyID, string taskId, uint256 quorumThresholdCount, uint256 expireByTime, address[] signerAddresses)",
+  ),
+  parseAbiItem(
+    "event Deposited(uint256 indexed depositId, address indexed sender, bytes32 indexed recipientSaltHash, uint32 tokenIndex, uint256 amount, bool isEligible, uint256 depositedAt)",
+  ),
+] as const;
+
+/**
+ * Intmax froze withdrawals so we will hit rate limit if we search logs from the latest block.
+ */
+export const WITHDRAW_ETH_FROM_BLOCK = 29328200n;
+
+/**
+ * INTMAX Withdrawal contract on Scroll (L2) that handles withdrawal proof submission and processing:
+ * https://github.com/InternetMaximalism/intmax2-contract/blob/main/contracts/withdrawal/Withdrawal.sol
+ */
+export const INTMAX_WITHDRAWAL_PROXY: Hex = "0x86B06D2604D9A6f9760E8f691F86d5B2a7C9c449";
+
+/**
+ * Withdrawal.submitWithdrawalProof function on Scroll (L2) - Called by the end user to initiate withdrawal to Ethereum.
+ * https://github.com/InternetMaximalism/intmax2-contract/blob/main/contracts/withdrawal/Withdrawal.sol#L147
+ *
+ * This is the user-facing transaction that initiates the withdrawal process:
+ * 1. User submits withdrawal proof on Withdrawal contract (Scroll L2) - this is the tx the end user pays
+ * 2. Withdrawal contract validates the ZK proof and marks withdrawals
+ * 3. Withdrawal contract sends cross-chain message to Liquidity contract (Ethereum L1)
+ * 4. On Ethereum, Liquidity.processWithdrawals delivers assets to recipient
+ *
+ * Emits:
+ * DirectWithdrawalQueued() - Emitted for each withdrawal that can be sent directly (direct withdrawal tokens)
+ * DirectWithdrawalQueued() - Emitted for each withdrawal
+ * DirectWithdrawalQueued() - Emitted for each withdrawal
+ * DirectWithdrawalQueued() - Emitted for each withdrawal
+ * DirectWithdrawalQueued() - Emitted for each withdrawal
+ * AppendMessage() - From the L2 Message Queue (0x5300000000000000000000000000000000000000)
+ * SentMessage()- From the L2 Scroll Messenger (0x781e90f1c8fc4611c9b7497c3b47f99ef6969cbc)
+ * ContributionRecorded() - From the Contribution contract to track withdrawal contributions
+ *
+ * Example:
+ * https://scrollscan.com/tx/0x7613bc4349afc1946cb124ea4c64b295951c101d87c808f9b1ae3950268a3747#eventlog
+ */
+export const WITHDRAW_ETH_EVENTS = [
+  parseAbiItem(
+    "event DirectWithdrawalQueued(bytes32 indexed withdrawalHash, address indexed recipient, (address, uint32, uint256, bytes32) withdrawal)",
+  ),
+  parseAbiItem(
+    "event DirectWithdrawalQueued(bytes32 indexed withdrawalHash, address indexed recipient, (address, uint32, uint256, bytes32) withdrawal)",
+  ),
+  parseAbiItem(
+    "event DirectWithdrawalQueued(bytes32 indexed withdrawalHash, address indexed recipient, (address, uint32, uint256, bytes32) withdrawal)",
+  ),
+  parseAbiItem(
+    "event DirectWithdrawalQueued(bytes32 indexed withdrawalHash, address indexed recipient, (address, uint32, uint256, bytes32) withdrawal)",
+  ),
+  parseAbiItem(
+    "event DirectWithdrawalQueued(bytes32 indexed withdrawalHash, address indexed recipient, (address, uint32, uint256, bytes32) withdrawal)",
+  ),
+  parseAbiItem("event AppendMessage(uint256 index, bytes32 messageHash)"),
+  parseAbiItem(
+    "event SentMessage(address indexed sender, address indexed target, uint256 value, uint256 messageNonce, uint256 gasLimit, bytes message)",
+  ),
+  parseAbiItem(
+    "event ContributionRecorded(uint256 indexed periodNumber, bytes32 indexed tag, address indexed user, uint256 amount)",
+  ),
+] as const;

--- a/gas-benchmarks/src/intmax/index.ts
+++ b/gas-benchmarks/src/intmax/index.ts
@@ -1,0 +1,61 @@
+import type { GasMetrics } from "../utils/types.js";
+
+import { getEventLogs, getTransactionsWithEvents, getUniqueLogs, scrollPublicClient } from "../utils/rpc.js";
+import { getAverageMetrics } from "../utils/utils.js";
+
+import {
+  DEPOSIT_ETH_FROM_BLOCK,
+  WITHDRAW_ETH_FROM_BLOCK,
+  INTMAX_LIQUIDITY_PROXY,
+  INTMAX_WITHDRAWAL_PROXY,
+  MAX_OF_LOGS,
+  DEPOSIT_ETH_EVENTS,
+  WITHDRAW_ETH_EVENTS,
+} from "./constants.js";
+
+export class Intmax {
+  readonly name = "intmax";
+
+  readonly version = "1.0.0";
+
+  async benchmark(): Promise<Record<string, GasMetrics>> {
+    const [depositEth, withdrawEth] = await Promise.all([this.benchmarkDepositETH(), this.benchmarkWithdrawETH()]);
+
+    return { depositEth, withdrawEth };
+  }
+
+  async benchmarkDepositETH(): Promise<GasMetrics> {
+    const logs = await getEventLogs({
+      contractAddress: INTMAX_LIQUIDITY_PROXY,
+      events: DEPOSIT_ETH_EVENTS,
+      maxLogs: MAX_OF_LOGS,
+      fromBlock: DEPOSIT_ETH_FROM_BLOCK,
+    });
+    const uniqueLogs = getUniqueLogs(logs);
+    const txs = await getTransactionsWithEvents(uniqueLogs, DEPOSIT_ETH_EVENTS);
+
+    if (txs.length === 0) {
+      throw new Error(`No deposit ETH transactions found for ${this.name}.`);
+    }
+
+    return getAverageMetrics(txs);
+  }
+
+  async benchmarkWithdrawETH(): Promise<GasMetrics> {
+    const logs = await getEventLogs({
+      contractAddress: INTMAX_WITHDRAWAL_PROXY,
+      events: WITHDRAW_ETH_EVENTS,
+      maxLogs: MAX_OF_LOGS,
+      fromBlock: WITHDRAW_ETH_FROM_BLOCK,
+      client: scrollPublicClient,
+    });
+    const uniqueLogs = getUniqueLogs(logs);
+    const txs = await getTransactionsWithEvents(uniqueLogs, WITHDRAW_ETH_EVENTS, scrollPublicClient);
+
+    if (txs.length === 0) {
+      throw new Error(`No withdraw ETH transactions found for ${this.name}.`);
+    }
+
+    return getAverageMetrics(txs);
+  }
+}

--- a/gas-benchmarks/src/utils/constants.ts
+++ b/gas-benchmarks/src/utils/constants.ts
@@ -4,6 +4,8 @@ config();
 
 export const ETH_RPC_URL = String(process.env.ETH_RPC_URL);
 
+export const SCROLL_RPC_URL = String(process.env.SCROLL_RPC_URL);
+
 export const BLOCK_RANGE = 1_000n;
 
 export const MAX_NUMBER_OF_RPC_TRIES = Number(process.env.MAX_NUMBER_OF_RPC_TRIES);

--- a/gas-benchmarks/src/utils/types.ts
+++ b/gas-benchmarks/src/utils/types.ts
@@ -1,4 +1,4 @@
-import type { AbiEvent, Hex } from "viem";
+import type { AbiEvent, Hex, PublicClient } from "viem";
 
 export interface GasMetrics {
   averageGasUsed: bigint | "no-data";
@@ -11,6 +11,7 @@ export interface GetEventLogs {
   events: readonly AbiEvent[];
   maxLogs: number;
   fromBlock?: bigint;
+  client?: PublicClient;
 }
 
 export type BenchmarkDb = Record<string, Record<string, GasMetrics | undefined>>;

--- a/gas-benchmarks/src/utils/utils.ts
+++ b/gas-benchmarks/src/utils/utils.ts
@@ -5,6 +5,24 @@ import { BLOCK_RANGE } from "./constants.js";
 
 export const getBlockInRange = (block: bigint): bigint => (block > BLOCK_RANGE ? block - BLOCK_RANGE + 1n : 0n);
 
+export const getFromAndToBlocks = (
+  latestBlock: bigint,
+  initialFromBlock?: bigint,
+): { fromBlock: bigint; toBlock: bigint } => {
+  let fromBlock;
+  let toBlock;
+
+  if (initialFromBlock) {
+    fromBlock = initialFromBlock;
+    toBlock = latestBlock - fromBlock > BLOCK_RANGE ? fromBlock + BLOCK_RANGE : latestBlock;
+  } else {
+    toBlock = latestBlock;
+    fromBlock = getBlockInRange(toBlock);
+  }
+
+  return { fromBlock, toBlock };
+};
+
 export const getAverageMetrics = (txs: TransactionReceipt[]): GasMetrics => {
   if (txs.length === 0) {
     return {


### PR DESCRIPTION
Blocked by https://github.com/privacy-ethereum/private-transfers-benchmarks/pull/18 (do not review until it is merged)

- Add intmax for benchmarking (shield in Ethereum, unshield in Scroll but receives ETH in Ethereum)
- Refactor some util functions (multiple public clients, better from and to blocks, broad test coverage)
- Add instructions for AI agents

**IMPORTANT:** I will squash commits after previous PR is merged