### PR TITLE
feat: benchmark against time window

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,25 +28,18 @@
 - Exception: loops acceptable for complex control flow (see `src/utils/rpc.ts` pagination)
 - Examples: `src/utils/utils.ts`, `src/utils/rpc.ts`, `src/index.ts`
 
-## 4. Type Organization
-
-- **ALL** types/interfaces MUST be in dedicated `types.ts` files
-- **NEVER** define types inline in implementation files
-- Locations: `src/utils/types.ts` (shared), `src/__tests__/types.ts` (test-specific)
-- Use inline type imports: `import type { Type } from "./types.js";`
-
-## 5. Utility Function Organization
+## 4. Utility Function Organization
 
 - **ALL** reusable functions MUST be in dedicated utility files
 - **NEVER** define utilities inline with implementation code
 - Locations: `src/utils/utils.ts`, `src/utils/rpc.ts`, `src/utils/db.ts`, `src/__tests__/utils.ts`
 - Prefer pure functions that minimize side effects
 
-## 6. Clean Code Principles
+## 5. Clean Code Principles
 
 - Follow Clean Code guidelines, but rules 1-4 above take precedence if there's a conflict
 
-## 7. Testing Requirements
+## 6. Testing Requirements
 
 - **ALWAYS** run `pnpm run test` and `pnpm run benchmark` after changes
 - Do NOT complete work without running these verification steps

--- a/.github/workflows/gas-benchmarks.yml
+++ b/.github/workflows/gas-benchmarks.yml
@@ -45,4 +45,4 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
           SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
-          NUMBER_OF_TRANSACTIONS: ${{ vars.NUMBER_OF_TRANSACTIONS }}
+          MIN_SAMPLES: ${{ vars.MIN_SAMPLES }}

--- a/gas-benchmarks/.env.example
+++ b/gas-benchmarks/.env.example
@@ -1,7 +1,3 @@
 ETH_RPC_URL=https://mainnet.gateway.tenderly.co
 
 SCROLL_RPC_URL=https://scroll.gateway.tenderly.co
-
-NUMBER_OF_TRANSACTIONS=100
-
-MAX_NUMBER_OF_RPC_TRIES=50

--- a/gas-benchmarks/src/__tests__/constants.test.ts
+++ b/gas-benchmarks/src/__tests__/constants.test.ts
@@ -30,7 +30,7 @@ describe("constants.ts files", () => {
     files.forEach(({ filePath, addresses }) => {
       expect(
         addresses.length,
-        `${filePath} must have at least one contract address (Hex-typed constant)`,
+        `${filePath} must have at least one contract address (Address-typed constant)`,
       ).toBeGreaterThanOrEqual(1);
     });
   });

--- a/gas-benchmarks/src/__tests__/utils.ts
+++ b/gas-benchmarks/src/__tests__/utils.ts
@@ -39,7 +39,7 @@ export function parseConstantsFile(filePath: string): { addresses: AddressEntry[
   const events: EventsEntry[] = [];
 
   // Match JSDoc block followed by a Hex-typed export const
-  const hexRegEx = /\/\*\*([\s\S]*?)\*\/\s*export const (\w+)\s*:\s*Hex\s*=/g;
+  const hexRegEx = /\/\*\*([\s\S]*?)\*\/\s*export const (\w+)\s*:\s*Address\s*=/g;
   let match = hexRegEx.exec(source);
 
   while (match !== null) {

--- a/gas-benchmarks/src/intmax/constants.ts
+++ b/gas-benchmarks/src/intmax/constants.ts
@@ -1,23 +1,13 @@
-import { parseAbiItem, type Hex } from "viem";
+import { parseAbiItem, type Address } from "viem";
 
-import { NUMBER_OF_TRANSACTIONS } from "../utils/constants.js";
-
-/**
- * Maximum number of logs with a Deposited event to be searched.
- * Depends on the ratio of how many AA txs - EOA txs
- */
-export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 10;
-
-/**
- * Intmax froze deposits so we will hit rate limit if we search logs from the latest block.
- */
-export const DEPOSIT_ETH_FROM_BLOCK = 24402900n;
+/** Last block before Intmax froze deposits on Ethereum mainnet */
+export const DEPOSIT_ETH_FROM_BLOCK = 24_402_900n;
 
 /**
  * INTMAX Liquidity contract on Ethereum mainnet that handles ETH native deposits and withdrawals:
  * https://github.com/InternetMaximalism/intmax2-contract/blob/main/contracts/liquidity/Liquidity.sol
  */
-export const INTMAX_LIQUIDITY_PROXY: Hex = "0xF65e73aAc9182e353600a916a6c7681F810f79C3";
+export const INTMAX_LIQUIDITY_PROXY: Address = "0xF65e73aAc9182e353600a916a6c7681F810f79C3";
 
 /**
  * Liquidity.depositNativeToken function:
@@ -43,16 +33,14 @@ export const DEPOSIT_ETH_EVENTS = [
   ),
 ] as const;
 
-/**
- * Intmax froze withdrawals so we will hit rate limit if we search logs from the latest block.
- */
-export const WITHDRAW_ETH_FROM_BLOCK = 29328200n;
+/** Last block before Intmax froze withdrawals on Scroll */
+export const WITHDRAW_ETH_FROM_BLOCK = 29_328_200n;
 
 /**
  * INTMAX Withdrawal contract on Scroll (L2) that handles withdrawal proof submission and processing:
  * https://github.com/InternetMaximalism/intmax2-contract/blob/main/contracts/withdrawal/Withdrawal.sol
  */
-export const INTMAX_WITHDRAWAL_PROXY: Hex = "0x86B06D2604D9A6f9760E8f691F86d5B2a7C9c449";
+export const INTMAX_WITHDRAWAL_PROXY: Address = "0x86B06D2604D9A6f9760E8f691F86d5B2a7C9c449";
 
 /**
  * Withdrawal.submitWithdrawalProof function on Scroll (L2) - Called by the end user to initiate withdrawal to Ethereum.

--- a/gas-benchmarks/src/privacy-pools/constants.ts
+++ b/gas-benchmarks/src/privacy-pools/constants.ts
@@ -1,18 +1,10 @@
-import { parseAbiItem, type Hex } from "viem";
-
-import { NUMBER_OF_TRANSACTIONS } from "../utils/constants.js";
-
-/**
- * Maximum number of logs with a Deposited event to be searched.
- * Depends on the ratio of how many AA txs - EOA txs
- */
-export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 5;
+import { parseAbiItem, type Address } from "viem";
 
 /**
  * Proxy contract address for the Privacy Pools Entrypoint:
  * https://github.com/0xbow-io/privacy-pools-core/blob/main/packages/contracts/src/contracts/Entrypoint.sol
  */
-export const PRIVACY_POOLS_ENTRYPOINT_PROXY: Hex = "0x6818809EefCe719E480a7526D76bD3e561526b46";
+export const PRIVACY_POOLS_ENTRYPOINT_PROXY: Address = "0x6818809EefCe719E480a7526D76bD3e561526b46";
 
 /**
  * Entrypoint.deposit function:

--- a/gas-benchmarks/src/railgun/constants.ts
+++ b/gas-benchmarks/src/railgun/constants.ts
@@ -1,14 +1,4 @@
-import { parseAbiItem, type Hex } from "viem";
-
-import { NUMBER_OF_TRANSACTIONS } from "../utils/constants.js";
-
-/**
- * Maximum number of logs with a Shield event to be searched.
- * Depends on the ratio of how many AA txs - EOA txs
- *
- * Railgun appears to have disperse single unshield txs
- */
-export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 20;
+import { parseAbiItem, type Address } from "viem";
 
 /**
  * Proxy contract that points to the RailgunSmartWallet contract:
@@ -17,7 +7,7 @@ export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 20;
  * NOTE: Railgun does not support native ETH, only ERC20 tokens.
  * Reference: https://docs.railgun.org/developer-guide/wallet/transactions/shielding/shield-base-token
  */
-export const RAILGUN_SMART_WALLET_PROXY: Hex = "0xfa7093cdd9ee6932b4eb2c9e1cde7ce00b1fa4b9";
+export const RAILGUN_SMART_WALLET_PROXY: Address = "0xfa7093cdd9ee6932b4eb2c9e1cde7ce00b1fa4b9";
 
 /**
  * RailgunSmartWallet.shield function:

--- a/gas-benchmarks/src/railgun/index.ts
+++ b/gas-benchmarks/src/railgun/index.ts
@@ -1,10 +1,12 @@
+import { mainnet } from "viem/chains";
+
 import type { GasMetrics } from "../utils/types.js";
 
-import { getEventLogs, getTransactionsWithEvents, getUniqueLogs } from "../utils/rpc.js";
+import { MIN_SAMPLES } from "../utils/constants.js";
+import { getValidTransactions } from "../utils/rpc.js";
 import { getAverageMetrics } from "../utils/utils.js";
 
 import {
-  MAX_OF_LOGS,
   RAILGUN_SMART_WALLET_PROXY,
   SHIELD_ERC20_EVENTS,
   TRANSFER_ERC20_EVENTS,
@@ -27,50 +29,44 @@ export class Railgun {
   }
 
   async benchmarkShieldERC20(): Promise<GasMetrics> {
-    const logs = await getEventLogs({
+    const receipts = await getValidTransactions({
       contractAddress: RAILGUN_SMART_WALLET_PROXY,
       events: SHIELD_ERC20_EVENTS,
-      maxLogs: MAX_OF_LOGS,
+      chain: mainnet,
     });
-    const uniqueLogs = getUniqueLogs(logs);
-    const txs = await getTransactionsWithEvents(uniqueLogs, SHIELD_ERC20_EVENTS);
 
-    if (txs.length === 0) {
-      throw new Error(`No shield ERC20 transactions found for ${this.name}.`);
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} shield ERC20: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
     }
 
-    return getAverageMetrics(txs);
+    return getAverageMetrics(receipts);
   }
 
   async benchmarkUnshieldERC20(): Promise<GasMetrics> {
-    const logs = await getEventLogs({
+    const receipts = await getValidTransactions({
       contractAddress: RAILGUN_SMART_WALLET_PROXY,
       events: UNSHIELD_ERC20_EVENTS,
-      maxLogs: MAX_OF_LOGS,
+      chain: mainnet,
     });
-    const uniqueLogs = getUniqueLogs(logs);
-    const txs = await getTransactionsWithEvents(uniqueLogs, UNSHIELD_ERC20_EVENTS);
 
-    if (txs.length === 0) {
-      throw new Error(`No unshield ERC20 transactions found for ${this.name}.`);
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} unshield ERC20: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
     }
 
-    return getAverageMetrics(txs);
+    return getAverageMetrics(receipts);
   }
 
   async benchmarkTransferERC20(): Promise<GasMetrics> {
-    const logs = await getEventLogs({
+    const receipts = await getValidTransactions({
       contractAddress: RAILGUN_SMART_WALLET_PROXY,
       events: TRANSFER_ERC20_EVENTS,
-      maxLogs: MAX_OF_LOGS,
+      chain: mainnet,
     });
-    const uniqueLogs = getUniqueLogs(logs);
-    const txs = await getTransactionsWithEvents(uniqueLogs, TRANSFER_ERC20_EVENTS);
 
-    if (txs.length === 0) {
-      throw new Error(`No transfer ERC20 transactions found for ${this.name}.`);
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} transfer ERC20: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
     }
 
-    return getAverageMetrics(txs);
+    return getAverageMetrics(receipts);
   }
 }

--- a/gas-benchmarks/src/tornado-cash/constants.ts
+++ b/gas-benchmarks/src/tornado-cash/constants.ts
@@ -1,18 +1,10 @@
-import { parseAbiItem, type Hex } from "viem";
-
-import { NUMBER_OF_TRANSACTIONS } from "../utils/constants.js";
-
-/**
- * Maximum number of logs with a Shield event to be searched.
- * Depends on the ratio of how many AA txs - EOA txs
- */
-export const MAX_OF_LOGS = NUMBER_OF_TRANSACTIONS * 5;
+import { parseAbiItem, type Address } from "viem";
 
 /**
  * Tornado Cash Router contract that directs deposits to different pools (ETH, ERC20 0.1, ERC20 1, ERC20 10, ERC20 100):
  * https://github.com/contractscan/etherscan.io-0xd90e2f925da726b50c4ed8d0fb90ad053324f31b/blob/main/TornadoRouter.sol
  */
-export const TORNADO_CASH_ROUTER: Hex = "0xd90e2f925DA726b50C4Ed8D0Fb90Ad053324F31b";
+export const TORNADO_CASH_ROUTER: Address = "0xd90e2f925DA726b50C4Ed8D0Fb90Ad053324F31b";
 
 /**
  * TornadoRouter.deposit function:
@@ -35,7 +27,7 @@ export const SHIELD_ETH_EVENTS = [
  * After it, a pool (ETH, ERC20 0.1, ERC20 1, ERC20 10, ERC20 100) emits a Withdrawal event.
  * https://github.com/contractscan/etherscan.io-0xd90e2f925da726b50c4ed8d0fb90ad053324f31b/blob/main/RelayerRegistry.sol
  */
-export const TORNADO_CASH_RELAYER_REGISTRY: Hex = "0x58E8dCC13BE9780fC42E8723D8EaD4CF46943dF2";
+export const TORNADO_CASH_RELAYER_REGISTRY: Address = "0x58E8dCC13BE9780fC42E8723D8EaD4CF46943dF2";
 
 /**
  * TornadoRegistry.registry function:

--- a/gas-benchmarks/src/tornado-cash/index.ts
+++ b/gas-benchmarks/src/tornado-cash/index.ts
@@ -1,10 +1,12 @@
+import { mainnet } from "viem/chains";
+
 import type { GasMetrics } from "../utils/types.js";
 
-import { getEventLogs, getTransactionsWithEvents, getUniqueLogs } from "../utils/rpc.js";
+import { MIN_SAMPLES } from "../utils/constants.js";
+import { getValidTransactions } from "../utils/rpc.js";
 import { getAverageMetrics } from "../utils/utils.js";
 
 import {
-  MAX_OF_LOGS,
   SHIELD_ETH_EVENTS,
   TORNADO_CASH_RELAYER_REGISTRY,
   TORNADO_CASH_ROUTER,
@@ -23,34 +25,30 @@ export class TornadoCash {
   }
 
   async benchmarkShieldETH(): Promise<GasMetrics> {
-    const logs = await getEventLogs({
+    const receipts = await getValidTransactions({
       contractAddress: TORNADO_CASH_ROUTER,
       events: SHIELD_ETH_EVENTS,
-      maxLogs: MAX_OF_LOGS,
+      chain: mainnet,
     });
-    const uniqueLogs = getUniqueLogs(logs);
-    const txs = await getTransactionsWithEvents(uniqueLogs, SHIELD_ETH_EVENTS);
 
-    if (txs.length === 0) {
-      throw new Error(`No shield ETH transactions found for ${this.name}.`);
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} shield ETH: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
     }
 
-    return getAverageMetrics(txs);
+    return getAverageMetrics(receipts);
   }
 
   async benchmarkUnshieldETH(): Promise<GasMetrics> {
-    const logs = await getEventLogs({
+    const receipts = await getValidTransactions({
       contractAddress: TORNADO_CASH_RELAYER_REGISTRY,
       events: UNSHIELD_ETH_EVENTS,
-      maxLogs: MAX_OF_LOGS,
+      chain: mainnet,
     });
-    const uniqueLogs = getUniqueLogs(logs);
-    const txs = await getTransactionsWithEvents(uniqueLogs, UNSHIELD_ETH_EVENTS);
 
-    if (txs.length === 0) {
-      throw new Error(`No unshield ETH transactions found for ${this.name}.`);
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} unshield ETH: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
     }
 
-    return getAverageMetrics(txs);
+    return getAverageMetrics(receipts);
   }
 }

--- a/gas-benchmarks/src/utils/constants.ts
+++ b/gas-benchmarks/src/utils/constants.ts
@@ -2,14 +2,42 @@ import { config } from "dotenv";
 
 config();
 
-export const ETH_RPC_URL = String(process.env.ETH_RPC_URL);
+if (!process.env.ETH_RPC_URL) {
+  throw new Error("ETH_RPC_URL is not set");
+}
 
-export const SCROLL_RPC_URL = String(process.env.SCROLL_RPC_URL);
+if (!process.env.SCROLL_RPC_URL) {
+  throw new Error("SCROLL_RPC_URL is not set");
+}
 
-export const BLOCK_RANGE = 1_000n;
+if (!process.env.MIN_SAMPLES) {
+  throw new Error("MIN_SAMPLES is not set");
+}
 
-export const MAX_NUMBER_OF_RPC_TRIES = Number(process.env.MAX_NUMBER_OF_RPC_TRIES);
+export const { ETH_RPC_URL } = process.env;
+export const { SCROLL_RPC_URL } = process.env;
 
-export const NUMBER_OF_TRANSACTIONS = Number(process.env.NUMBER_OF_TRANSACTIONS);
+/** Minimum number of valid samples required per benchmark */
+export const MIN_SAMPLES = Number(process.env.MIN_SAMPLES);
+
+/** Maximum unique logs to collect before stopping the block scan */
+export const MAX_SAMPLES = 100_000;
+
+/** Number of blocks to fetch per RPC getLogs call */
+export const BLOCK_RANGE = 2_000n;
 
 export const BENCHMARKS_OUTPUT_PATH = "./benchmarks.json";
+
+/**
+ * The number of Ethereum blocks to scan for events
+ * 1 week = 604800 seconds. 1 Ethereum block = 12 seconds
+ * 604800 / 12 = 50400 seconds
+ */
+export const BLOCK_WINDOW_ETHEREUM = 50_400n;
+
+/**
+ * The number of Scroll blocks to scan for events
+ * 1 week = 604800 seconds. 1 Scroll block = 1 second
+ * 604800 / 1 = 604800 seconds
+ */
+export const BLOCK_WINDOW_SCROLL = 604_800n;

--- a/gas-benchmarks/src/utils/db.ts
+++ b/gas-benchmarks/src/utils/db.ts
@@ -2,9 +2,11 @@ import { Low } from "lowdb";
 
 import { readFile, writeFile } from "node:fs/promises";
 
-import type { BenchmarkDb } from "./types.js";
+import type { GasMetrics } from "./types.js";
 
 import { BENCHMARKS_OUTPUT_PATH } from "./constants.js";
+
+type BenchmarkDb = Record<string, Record<string, GasMetrics | undefined>>;
 
 const serializeBigInt = (_key: string, value: unknown) => (typeof value === "bigint" ? `${value.toString()}n` : value);
 

--- a/gas-benchmarks/src/utils/types.ts
+++ b/gas-benchmarks/src/utils/types.ts
@@ -1,17 +1,5 @@
-import type { AbiEvent, Hex, PublicClient } from "viem";
-
 export interface GasMetrics {
   averageGasUsed: bigint | "no-data";
   averageGasPrice: bigint | "no-data";
   averageTxFee: bigint | "no-data";
 }
-
-export interface GetEventLogs {
-  contractAddress: Hex;
-  events: readonly AbiEvent[];
-  maxLogs: number;
-  fromBlock?: bigint;
-  client?: PublicClient;
-}
-
-export type BenchmarkDb = Record<string, Record<string, GasMetrics | undefined>>;

--- a/gas-benchmarks/src/utils/utils.ts
+++ b/gas-benchmarks/src/utils/utils.ts
@@ -1,28 +1,6 @@
 import type { GasMetrics } from "./types.js";
 import type { TransactionReceipt } from "viem";
 
-import { BLOCK_RANGE } from "./constants.js";
-
-export const getBlockInRange = (block: bigint): bigint => (block > BLOCK_RANGE ? block - BLOCK_RANGE + 1n : 0n);
-
-export const getFromAndToBlocks = (
-  latestBlock: bigint,
-  initialFromBlock?: bigint,
-): { fromBlock: bigint; toBlock: bigint } => {
-  let fromBlock;
-  let toBlock;
-
-  if (initialFromBlock) {
-    fromBlock = initialFromBlock;
-    toBlock = latestBlock - fromBlock > BLOCK_RANGE ? fromBlock + BLOCK_RANGE : latestBlock;
-  } else {
-    toBlock = latestBlock;
-    fromBlock = getBlockInRange(toBlock);
-  }
-
-  return { fromBlock, toBlock };
-};
-
 export const getAverageMetrics = (txs: TransactionReceipt[]): GasMetrics => {
   if (txs.length === 0) {
     return {


### PR DESCRIPTION
### What does this PR do?
  - Scan full a 7-day block window instead of sampling a few hundred receipts
      - Use `BLOCK_WINDOW_ETHEREUM` & `BLOCK_WINDOW_SCROLL` for defining 7 day window
  - Remove `MAX_OF_LOGS` per protocol. This is because we are using a time window based approach. We can keep an eye on Alchemy api key usage and optimise if requests become too cost prohibitive. The account already has a max usage policy to protect against very high usage.  
  - Remove `NUMBER_OF_TRANSACTIONS` for same reasons as above
  - Add `MIN_SAMPLES` = 50. This is a minimum floor we want for averages. Maybe 50 could be too high, as some protocols might not get a lot of use at all. In which case, we could remove, adjust this later
  - Add `MAX_SAMPLES` = 100,000. This is a safety guard to prevent us from sending extremely high amounts of rpc requests
  - Increase `BLOCK_RANGE` to 2000. It appears 2000 is a [safe option](https://www.alchemy.com/docs/chains/ethereum/ethereum-api-endpoints/eth-get-logs) for `getLogs`
  - Merge `getEventLogs` + `getTransactionsWithEvents` into single
  `getValidTransactions` function. 
  - `getValidTransactions` calls `getAllLogs` & `getValidReceipts`
      - `getAllLogs` — scans blocks in chunks from newest to oldest, deduplicates by
  tx hash in a single pass using an inline Set
    - `getValidReceipts` — fetches receipts and filters to those whose log count
  and event topics match the expected pattern
  - Deduplicate logs in a single pass using inline Set instead of separate
  `getUniqueLogs` calls
  - Make choice of `chain` and explicit choice in order to use correct client and block window logic. This becomes more important as we add more chains (e.g. protocol only deployed on Base)
- Add minor natspec comments
- Move stable env vars definition to constants
- Add env var validation
  
### Some changes to simplify logic
  - Remove `reduce` and use for..of
  - Move `getBlockInRange` and `getFromAndToBlocks` inline
  - Move types and utils defined once inline if it didn't add to LoC too much

### Why do we want to scan by a consistent block window?

The main reason we want to do this is because if we get 200 receipts per protocol, that will mean very different things depending on protocol usage. If protocol A has 200 valid txs in one week, whereas protocol B has 20,000 valid txs in one week, then we are not getting an equivalent average of both. The average of the protocol with 200 in week will encompass gas prices from 7 whole days, whereas protocol B might only have an average based on a day of usage.

This way, protocol benchmarks reflect the same range in gas prices, and subsequent changes that has on utilisation (gas prices may impact how much people use the chain).