### PR TITLE
feat(benchmarks): add redact

### DIFF
--- a/gas-benchmarks/.env.example
+++ b/gas-benchmarks/.env.example
@@ -2,6 +2,8 @@ ETH_RPC_URL=https://mainnet.gateway.tenderly.co
 
 SCROLL_RPC_URL=https://scroll.gateway.tenderly.co
 
+SEPOLIA_RPC_URL=https://sepolia.gateway.tenderly.co
+
 MONERO_FAIL_NODES_API_URL=https://monero.fail/nodes.json
 
 MIN_SAMPLES=10

--- a/gas-benchmarks/src/index.ts
+++ b/gas-benchmarks/src/index.ts
@@ -4,6 +4,7 @@ import { Intmax } from "./intmax/index.js";
 import { Monero } from "./monero/index.js";
 import { PrivacyPools } from "./privacy-pools/index.js";
 import { Railgun } from "./railgun/index.js";
+import { Redact } from "./redact/index.js";
 import { TornadoCash } from "./tornado-cash/index.js";
 import { db } from "./utils/db.js";
 
@@ -14,6 +15,7 @@ const intmax = new Intmax();
 const monero = new Monero();
 const hinkal = new Hinkal();
 const fluidkey = new Fluidkey();
+const redact = new Redact();
 
 await db.read();
 
@@ -27,6 +29,7 @@ const [
   moneroMetrics,
   hinkalMetrics,
   fluidkeyMetrics,
+  redactMetrics,
 ] = await Promise.all([
   railgun.benchmark(),
   tornadoCash.benchmark(),
@@ -35,6 +38,7 @@ const [
   monero.benchmark(),
   hinkal.benchmark(),
   fluidkey.benchmark(),
+  redact.benchmark(),
 ]);
 
 await db.update((data) => {
@@ -84,6 +88,12 @@ await db.update((data) => {
     shield_erc20: fluidkeyMetrics.shieldErc20,
     transfer_eth: fluidkeyMetrics.transferEth,
     transfer_erc20: fluidkeyMetrics.transferErc20,
+  };
+
+  // eslint-disable-next-line no-param-reassign
+  data[`${redact.name}_${redact.version}`] = {
+    encrypt_eth: redactMetrics.encryptEth,
+    decrypt_eth: redactMetrics.decryptEth,
   };
 });
 

--- a/gas-benchmarks/src/redact/constants.ts
+++ b/gas-benchmarks/src/redact/constants.ts
@@ -1,0 +1,195 @@
+import { parseAbiItem, type Address } from "viem";
+
+import type { ProtocolConfig } from "../utils/types.js";
+
+/**
+ * FHERC20 Confidential Ether eETH:
+ */
+const CONFIDENTIAL_ETHER_PROXY: Address = "0xC132c8a82A24Fe1e491082932e3db4F70Ce95c93";
+
+/**
+ * ConfidentialETH.shieldNative function (inherited from FHERC20NativeWrapperUpgradeable.sol):
+ *
+ * Emits:
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to encrypt (emitted by Task Manager of Fhenix coprocessor)
+ * Transfer() - Transfer to simulate a ERC20 transfer with dummy values (emitted by the confidential Eth contract)
+ * ConfidentialTransfer() - Encrypted token transfer announcement (emitted by the confidential Eth contract)
+ * ShieldedNative() - Shielded native ETH action (emitted by the confidential Eth contract)
+ */
+const ENCRYPT_ETH_EVENTS = [
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)"),
+  parseAbiItem("event ConfidentialTransfer(address indexed from, address indexed to, bytes32 indexed amount)"),
+  parseAbiItem("event ShieldedNative(address indexed from, address indexed to, uint256 value)"),
+] as const;
+
+/**
+ * ConfidentialETH.decrypt function:
+ *
+ * Emits:
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * Transfer() - Transfer to simulate a ERC20 transfer with dummy values (emitted by the confidential Eth contract)
+ * ConfidentialTransfer() - Encrypted token transfer announcement (emitted by the confidential Eth contract)
+ * Unshielded() - Unshielded native ETH action (emitted by the confidential Eth contract)
+ */
+const DECRYPT_ETH_EVENTS = [
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)"),
+  parseAbiItem("event ConfidentialTransfer(address indexed from, address indexed to, bytes32 indexed amount)"),
+  parseAbiItem("event Unshielded(address indexed to, bytes32 indexed amount)"),
+] as const;
+
+/**
+ * ConfidentialETH.claimAllDecrypted function:
+ *
+ * Emits:
+ * ClaimedUnshielded() - Claimed unshielded ETH transfer notification (emitted by the confidential wrapper contract)
+ *
+ */
+const CLAIM_DECRYPTED_ETH_EVENTS = [
+  parseAbiItem(
+    "event ClaimedUnshielded(address indexed to, bytes32 indexed unshieldRequestId, bytes32 indexed unshieldAmount, uint64 unshieldAmountCleartext)",
+  ),
+] as const;
+
+/**
+ * ConfidentialETH -> FHERC20NativeWrapperUpgradeable -> FHERC20Upgradeable.confidentialTransfer function:
+ *
+ * Emits:
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * TaskCreated() - Assigned task to decrypt (emitted by Task Manager of Fhenix coprocessor)
+ * Transfer() - Transfer to simulate a ERC20 transfer with dummy values (emitted by the confidential Eth contract)
+ * ConfidentialTransfer() - Encrypted token transfer announcement (emitted by the confidential Eth contract)
+ *
+ * It can be used by confidential ETH or confidential ERC20 tokens because both are FHERC20 confidential tokens.
+ */
+const ENCRYPTED_TOKEN_TRANSFER_EVENTS = [
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem(
+    "event TaskCreated(uint256 indexed taskId, string descriptionHash, uint256 maxBudget, uint256 commitDeadline, uint256 revealDeadline)",
+  ),
+  parseAbiItem("event Transfer(address indexed from, address indexed to, uint256 value)"),
+  parseAbiItem("event ConfidentialTransfer(address indexed from, address indexed to, bytes32 indexed amount)"),
+] as const;
+
+/** Redact configuration */
+const REDACT_CONFIG = {
+  name: "redact",
+  version: "1.0.0",
+  contracts: [
+    {
+      address: CONFIDENTIAL_ETHER_PROXY,
+      sourceUrl:
+        "https://github.com/FhenixProtocol/redact/blob/new-version-deployment/packages/hardhat/contracts/ConfidentialETH.sol",
+    },
+  ],
+  operations: [
+    {
+      functionSourceUrl:
+        "https://github.com/FhenixProtocol/fhenix-confidential-contracts/blob/0823e57e320c1c72e0caee7faeebc4d3a0710373/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol#L91",
+      exampleTxUrl:
+        "https://sepolia.etherscan.io/tx/0xf1758a8d42ef208d4e20b00445a9c6b75aa8ae21c7fa6c5dcbdde78b1efa1ac1",
+      events: ENCRYPT_ETH_EVENTS,
+    },
+    {
+      functionSourceUrl:
+        "https://github.com/FhenixProtocol/fhenix-confidential-contracts/blob/0823e57e320c1c72e0caee7faeebc4d3a0710373/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol#L112",
+      exampleTxUrl:
+        "https://sepolia.etherscan.io/tx/0xd0ce16c80d911ac3d5a9262f79372cff3b87291253e0163ced5c582a3b87e0cf",
+      events: DECRYPT_ETH_EVENTS,
+    },
+    {
+      functionSourceUrl:
+        "https://github.com/FhenixProtocol/fhenix-confidential-contracts/blob/0823e57e320c1c72e0caee7faeebc4d3a0710373/contracts/FHERC20/extensions/FHERC20NativeWrapperUpgradeable.sol#L135",
+      exampleTxUrl:
+        "https://sepolia.etherscan.io/tx/0x94b0cd3b3e8c7f53d7b9db497973ffd1b14b2dea3a6ef89f6b5561d775c4b649",
+      events: CLAIM_DECRYPTED_ETH_EVENTS,
+    },
+    {
+      functionSourceUrl:
+        "https://github.com/FhenixProtocol/fhenix-confidential-contracts/blob/0823e57e320c1c72e0caee7faeebc4d3a0710373/contracts/FHERC20/FHERC20Upgradeable.sol#L216",
+      exampleTxUrl:
+        "https://sepolia.etherscan.io/tx/0x9e2cc152f3c63cca0c02fcda4e2636776d00a304410b62ffcd110a9f4a664bcb",
+      events: ENCRYPTED_TOKEN_TRANSFER_EVENTS,
+    },
+  ],
+} satisfies ProtocolConfig;
+
+export {
+  CONFIDENTIAL_ETHER_PROXY,
+  ENCRYPT_ETH_EVENTS,
+  DECRYPT_ETH_EVENTS,
+  CLAIM_DECRYPTED_ETH_EVENTS,
+  ENCRYPTED_TOKEN_TRANSFER_EVENTS,
+  REDACT_CONFIG,
+};

--- a/gas-benchmarks/src/redact/index.ts
+++ b/gas-benchmarks/src/redact/index.ts
@@ -1,0 +1,109 @@
+import { sepolia } from "viem/chains";
+
+import type { FeeMetrics } from "../utils/types.js";
+
+import { BLOCK_WINDOW_ETHEREUM_3_DAYS, MIN_SAMPLES } from "../utils/constants.js";
+import { getValidTransactions } from "../utils/rpc.js";
+import { getAverageMetrics } from "../utils/utils.js";
+
+import {
+  CLAIM_DECRYPTED_ETH_EVENTS,
+  CONFIDENTIAL_ETHER_PROXY,
+  DECRYPT_ETH_EVENTS,
+  ENCRYPT_ETH_EVENTS,
+  ENCRYPTED_TOKEN_TRANSFER_EVENTS,
+  REDACT_CONFIG,
+} from "./constants.js";
+
+export class Redact {
+  readonly name = REDACT_CONFIG.name;
+
+  readonly version = REDACT_CONFIG.version;
+
+  async benchmark(): Promise<Record<string, FeeMetrics>> {
+    const [encryptEth, decryptEth] = await Promise.all([this.benchmarkEncryptETH(), this.benchmarkDecryptETH()]);
+
+    return { encryptEth, decryptEth };
+  }
+
+  async benchmarkEncryptETH(): Promise<FeeMetrics> {
+    const receipts = await getValidTransactions({
+      contractAddress: CONFIDENTIAL_ETHER_PROXY,
+      events: ENCRYPT_ETH_EVENTS,
+      chain: sepolia,
+      blockWindow: BLOCK_WINDOW_ETHEREUM_3_DAYS, // there are a lot of encrypted transfers so use a small block window to rate limit
+    });
+
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} encrypt ETH: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
+    }
+
+    return getAverageMetrics(receipts);
+  }
+
+  async benchmarkDecryptETH(): Promise<FeeMetrics> {
+    const [decryptReceipts, claimReceipts] = await Promise.all([
+      getValidTransactions({
+        contractAddress: CONFIDENTIAL_ETHER_PROXY,
+        events: DECRYPT_ETH_EVENTS,
+        chain: sepolia,
+        blockWindow: BLOCK_WINDOW_ETHEREUM_3_DAYS, // there are a lot of encrypted transfers so use a small block window to rate limit
+      }),
+      getValidTransactions({
+        contractAddress: CONFIDENTIAL_ETHER_PROXY,
+        events: CLAIM_DECRYPTED_ETH_EVENTS,
+        chain: sepolia,
+        blockWindow: BLOCK_WINDOW_ETHEREUM_3_DAYS, // there are a lot of encrypted transfers so use a small block window to rate limit
+      }),
+    ]);
+
+    if (decryptReceipts.length < MIN_SAMPLES) {
+      throw new Error(`${this.name} decrypt ETH: receipts (${decryptReceipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`);
+    }
+
+    if (claimReceipts.length < MIN_SAMPLES) {
+      throw new Error(
+        `${this.name} claim decrypted ETH: receipts (${claimReceipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`,
+      );
+    }
+
+    const decryptMetrics = getAverageMetrics(decryptReceipts);
+    const claimMetrics = getAverageMetrics(claimReceipts);
+
+    // Sum decrypt and claim metrics to get the final metrics for the end-user to fully exit (decrypt + claim)
+    const metrics: FeeMetrics = {
+      averageGasUsed:
+        decryptMetrics.averageGasUsed === "no-data" || claimMetrics.averageGasUsed === "no-data"
+          ? "no-data"
+          : Number(decryptMetrics.averageGasUsed) + Number(claimMetrics.averageGasUsed),
+      averageGasPrice:
+        decryptMetrics.averageGasPrice === "no-data" || claimMetrics.averageGasPrice === "no-data"
+          ? "no-data"
+          : Number(decryptMetrics.averageGasPrice) + Number(claimMetrics.averageGasPrice),
+      averageTxFee:
+        decryptMetrics.averageTxFee === "no-data" || claimMetrics.averageTxFee === "no-data"
+          ? "no-data"
+          : Number(decryptMetrics.averageTxFee) + Number(claimMetrics.averageTxFee),
+    };
+
+    return metrics;
+  }
+
+  // TODO: not enough txs at the moment (April 17th 2026). We can activate it later
+  async benchmarkEncryptedTokenTransfer(): Promise<FeeMetrics> {
+    const receipts = await getValidTransactions({
+      contractAddress: CONFIDENTIAL_ETHER_PROXY,
+      events: ENCRYPTED_TOKEN_TRANSFER_EVENTS,
+      chain: sepolia,
+      blockWindow: BLOCK_WINDOW_ETHEREUM_3_DAYS,
+    });
+
+    if (receipts.length < MIN_SAMPLES) {
+      throw new Error(
+        `${this.name} encrypted token transfer: receipts (${receipts.length}) < MIN_SAMPLES (${MIN_SAMPLES})`,
+      );
+    }
+
+    return getAverageMetrics(receipts);
+  }
+}

--- a/gas-benchmarks/src/utils/constants.ts
+++ b/gas-benchmarks/src/utils/constants.ts
@@ -10,12 +10,17 @@ if (!process.env.SCROLL_RPC_URL) {
   throw new Error("SCROLL_RPC_URL is not set");
 }
 
+if (!process.env.SEPOLIA_RPC_URL) {
+  throw new Error("SEPOLIA_RPC_URL is not set");
+}
+
 if (!process.env.MIN_SAMPLES) {
   throw new Error("MIN_SAMPLES is not set");
 }
 
 export const { ETH_RPC_URL } = process.env;
 export const { SCROLL_RPC_URL } = process.env;
+export const { SEPOLIA_RPC_URL } = process.env;
 
 /** Minimum number of valid samples required per benchmark */
 export const MIN_SAMPLES = Number(process.env.MIN_SAMPLES);
@@ -26,6 +31,9 @@ export const MAX_SAMPLES = 100_000;
 /** Number of blocks to fetch per RPC getLogs call */
 export const BLOCK_RANGE = 2_000n;
 
+/** How many RPC calls will be performed concurrently */
+export const BATCH_SIZE_FOR_RPC_CALLS = 1500;
+
 export const BENCHMARKS_OUTPUT_PATH = "./benchmarks.json";
 
 /**
@@ -34,6 +42,13 @@ export const BENCHMARKS_OUTPUT_PATH = "./benchmarks.json";
  * 600 / 12 = 50 blocks
  */
 export const BLOCK_WINDOW_ETHEREUM_10_MINUTES = 50n;
+
+/**
+ * The number of Ethereum blocks to scan for events for 3 days
+ * 3 days = 259200 seconds. 1 Ethereum block = 12 seconds
+ * 259200 / 12 = 21600 blocks
+ */
+export const BLOCK_WINDOW_ETHEREUM_3_DAYS = 21_600n;
 
 /**
  * The number of Ethereum blocks to scan for events for 1 week
@@ -64,8 +79,3 @@ export const BLOCK_WINDOW_SCROLL_1_WEEK = 604_800n;
  * Using 5 for dev and rate limiting on remote node
  */
 export const BLOCK_WINDOW_MONERO = 5;
-
-/**
- * One day in seconds used to calculate day of unixtimestamp
- */
-export const ONE_DAY_IN_SECONDS = 24 * 60 * 60;

--- a/gas-benchmarks/src/utils/http.ts
+++ b/gas-benchmarks/src/utils/http.ts
@@ -1,0 +1,69 @@
+import { sleep } from "./utils.js";
+
+const RETRY_BASE_DELAY_IN_MS = 1_000;
+const RETRY_JITTER_IN_MS = 250;
+const RETRY_MAX_ATTEMPTS = 4;
+
+const RATE_LIMIT_REGEX = /rate limit|too many requests|exceeded.*compute units/i;
+
+/**
+ * Check if the error is an object and has a nested property with key.
+ * @param error object
+ * @param key property key
+ * @returns value of the nested property
+ */
+const getNestedErrorValue = (error: unknown, key: string): unknown => {
+  const isObject = typeof error === "object" && error !== null;
+
+  if (!isObject) {
+    return undefined;
+  }
+
+  return (error as Record<string, unknown>)[key];
+};
+
+/**
+ * Check if the error is a rate limit error by looking for a 429 status code or a rate limit message in the error properties.
+ * @param error object
+ * @returns yes if the error is a rate limit error, no otherwise
+ * @dev different RPC providers return different error shapes, so we check multiple properties and nested properties for both the status code and the message.
+ */
+const isRateLimitError = (error: unknown): boolean => {
+  const code = getNestedErrorValue(error, "code") ?? getNestedErrorValue(getNestedErrorValue(error, "cause"), "code");
+  const details = getNestedErrorValue(error, "details");
+  const shortMessage = getNestedErrorValue(error, "shortMessage");
+  const message =
+    getNestedErrorValue(error, "message") ?? getNestedErrorValue(getNestedErrorValue(error, "cause"), "message");
+
+  const hasRateLimitMessage = [details, shortMessage, message].some(
+    (value) => typeof value === "string" && RATE_LIMIT_REGEX.test(value),
+  );
+
+  return code === 429 || hasRateLimitMessage;
+};
+
+/**
+ * Retry a request if it fails due to a rate limit error.
+ * @param request function that returns a promise
+ * @param maxAttempts maximum number of retry attempts
+ * @param attempt current attempt number (used recursively)
+ * @returns result of the request
+ */
+export const withRetries = async <T>(
+  request: () => Promise<T>,
+  maxAttempts = RETRY_MAX_ATTEMPTS,
+  attempt = 1,
+): Promise<T> => {
+  try {
+    return await request();
+  } catch (error) {
+    if (!isRateLimitError(error) || attempt >= maxAttempts) {
+      throw error;
+    }
+
+    const delay = RETRY_BASE_DELAY_IN_MS + Math.floor(Math.random() * (RETRY_JITTER_IN_MS + 1));
+    await sleep(delay);
+
+    return withRetries(request, maxAttempts, attempt + 1);
+  }
+};

--- a/gas-benchmarks/src/utils/rpc.ts
+++ b/gas-benchmarks/src/utils/rpc.ts
@@ -9,7 +9,7 @@ import {
   type PublicClient,
   type TransactionReceipt,
 } from "viem";
-import { mainnet, scroll } from "viem/chains";
+import { mainnet, scroll, sepolia } from "viem/chains";
 
 import type {
   EthGetBlockReceiptsSchema,
@@ -28,12 +28,16 @@ import {
   MAX_SAMPLES,
   BLOCK_WINDOW_ETHEREUM_1_WEEK,
   BLOCK_WINDOW_SCROLL_1_WEEK,
+  SEPOLIA_RPC_URL,
+  BATCH_SIZE_FOR_RPC_CALLS,
 } from "./constants.js";
-import { isNativeTransfer } from "./utils.js";
+import { withRetries } from "./http.js";
+import { isNativeTransfer, sleep } from "./utils.js";
 
 /** Pre-configured RPC clients keyed by chain ID */
 const clients: Record<number, PublicClient | undefined> = {
   [mainnet.id]: createPublicClient({ chain: mainnet, transport: http(ETH_RPC_URL, { batch: true }) }),
+  [sepolia.id]: createPublicClient({ chain: sepolia, transport: http(SEPOLIA_RPC_URL, { batch: true }) }),
   [scroll.id]: createPublicClient({ chain: scroll, transport: http(SCROLL_RPC_URL, { batch: true }) }),
 };
 
@@ -69,6 +73,8 @@ const getBlockWindow = async ({
     scanWindow = BLOCK_WINDOW_ETHEREUM_1_WEEK;
   } else if (chainId === scroll.id) {
     scanWindow = BLOCK_WINDOW_SCROLL_1_WEEK;
+  } else if (chainId === sepolia.id) {
+    scanWindow = BLOCK_WINDOW_ETHEREUM_1_WEEK;
   } else {
     throw new Error(`No block window configured for chain ID: ${chainId}`);
   }
@@ -100,6 +106,7 @@ const getAllLogs = async ({ client, contractAddress, events, scanEnd, scanStart 
     const batchLogs = await client.getLogs({
       address: contractAddress,
       events,
+      strict: true,
       fromBlock,
       toBlock,
     });
@@ -125,7 +132,21 @@ const getAllLogs = async ({ client, contractAddress, events, scanEnd, scanStart 
 const getValidReceipts = async ({ client, logs, events }: GetValidReceiptsInput): Promise<TransactionReceipt[]> => {
   const eventTopics = events.map((event) => encodeEventTopics({ abi: [event] })[0]);
 
-  const receipts = await Promise.all(logs.map((log) => client.getTransactionReceipt({ hash: log.transactionHash! })));
+  const receipts: TransactionReceipt[] = [];
+
+  for (let i = 0; i < logs.length; i += BATCH_SIZE_FOR_RPC_CALLS) {
+    const batch = logs.slice(i, i + BATCH_SIZE_FOR_RPC_CALLS);
+
+    // eslint-disable-next-line no-await-in-loop
+    const tempReceipts = await Promise.all(
+      batch.map((log) => withRetries(() => client.getTransactionReceipt({ hash: log.transactionHash! }))),
+    );
+
+    receipts.push(...tempReceipts);
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(100); // delay between batches to avoid overwhelming the RPC
+  }
 
   return receipts.filter((receipt) => {
     const hasExpectedLogCount = receipt.logs.length === events.length;

--- a/gas-benchmarks/src/utils/utils.ts
+++ b/gas-benchmarks/src/utils/utils.ts
@@ -32,3 +32,13 @@ export const isNativeTransfer = (receipt: TransactionReceipt): boolean => {
 
   return isGasUsed21000 && hasNoLogs && isNotContractDeployment && hasRecipient;
 };
+
+/**
+ * Sleep for a specified number of milliseconds
+ * @param ms - The number of milliseconds to sleep
+ * @returns A promise that resolves after the specified time has elapsed
+ */
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });


### PR DESCRIPTION
This PR adds the Redact (confidential token project built with Fhenix) to the current benchmarking methodology. I have found the following issues:

- I am having a lot of RPC rate limit errors. I am batching the concurrent requests to reduce the number of request per time period
- I also activated the strict mode in `client.getLogs()` but it does not seem to be doing anything useful in our case:

we assumed that `getLogs({ events: [...] })` will filter transactions with a specific log order but it does not work like that. It fetches all logs emitted from the specified address that adhere to any of the events structure. This makes it difficult to differentiate txs. For example in redact

1. **Shield:** send public ETH to contract and get encrypted ETH (eETH). This tx emits 10 events: 7 TaskCreated (for the Fhenix coprocessor), 1 Transfer, 1 ConfidentialTransfer and 1 ShieldedNative.
2. **Unshield:** send encrypted ETH (eETH) to public ETH. This tx emits 10 events: 7 TaskCreated (for the Fhenix coprocessor), 1 Transfer, 1 ConfidentialTransfer and 1 Unshielded. Worth pointing out that the unshield process involves Unshield and also Claim.
3. **Transfer:** send encrypted ETH (eETH) to another address. This tx emits 8 events: 6 TaskCreated (for the Fhenix coprocessor), 1 Transfer and 1 ConfidentialTransfer

As you can see all 3 types of tx emit ConfidentialTransfer and the only way to differentiate a **Transfer** from the other 2 is by counting the emitted events and checking it does not contain ShieldedNative or Unshielded.


We can merge this PR as reference and keep the above idea in mind when migrating to the subgraph methodology