### PR TITLE
feat: update research script

### DIFF
--- a/project-evaluations/scripts/README.md
+++ b/project-evaluations/scripts/README.md
@@ -1,0 +1,11 @@
+# Research scripts
+
+1. Add the protocol to `scripts/research-config.ts`.
+2. Run `/evaluate-protocol <id>`. All commands accept `--only "A,B"`.
+
+`/evaluate-protocol` composes several steps, alternatively, you can run each step separately:
+
+1. Add the protocol to `scripts/research-config.ts`.
+2. Run `/research-sources <id>` in Claude Code to write `scripts/research-cache/<id>.json`.
+3. Run `pnpm run research <id>` to write `src/data/evaluations/<id>.json`.
+4. Run `/review-evaluation <id>` to check against the rules in `scripts/research-prompts.ts`.

--- a/project-evaluations/scripts/index.ts
+++ b/project-evaluations/scripts/index.ts
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { PROPERTY_DEFINITIONS } from "../src/data/schema";
 import { configs } from "./research-config";
 import { evaluateProperties } from "./research-protocol";
 import { Evaluation, Property } from "../src/types";
@@ -12,7 +13,9 @@ async function main() {
   const protocolId = positional[0];
   if (!protocolId || !configs[protocolId]) {
     console.error(
-      `Usage: pnpm run research <protocol> [--only "A,B"]\n` + `Available: ${Object.keys(configs).join(", ")}`,
+      `Usage: pnpm run research <protocol> [--only "A,B"]\n` +
+        `Requires scripts/research-cache/<protocol>.json — generate it first with /research-sources <protocol> in Claude Code.\n` +
+        `Available: ${Object.keys(configs).join(", ")}`,
     );
     process.exit(1);
   }
@@ -23,7 +26,9 @@ async function main() {
 
   const config = configs[protocolId];
   const evalPath = new URL(`../src/data/evaluations/${config.id}.json`, import.meta.url);
-  const existingProperties: Property[] = JSON.parse(readFileSync(evalPath, "utf-8")).properties;
+  const existingProperties: Property[] = existsSync(evalPath)
+    ? JSON.parse(readFileSync(evalPath, "utf-8")).properties
+    : PROPERTY_DEFINITIONS.map((p) => ({ name: p.name, value: "" }));
 
   const properties = await evaluateProperties(config, existingProperties, only ?? []);
 

--- a/project-evaluations/scripts/research-cache/.gitignore
+++ b/project-evaluations/scripts/research-cache/.gitignore
@@ -1,0 +1,3 @@
+*.json
+sources/
+!.gitignore

--- a/project-evaluations/scripts/research-config.ts
+++ b/project-evaluations/scripts/research-config.ts
@@ -1,6 +1,10 @@
 import { Evaluation } from "../src/types";
 
-export type ProtocolConfig = Omit<Evaluation, "properties">;
+export type ProtocolConfig = Omit<Evaluation, "properties"> & {
+  /** Extra context injected into every research and evaluation prompt. Use this to
+   *  clarify what the protocol actually is vs. related specs, prevent common mistakes, etc. */
+  context?: string;
+};
 
 export const configs: Record<string, ProtocolConfig> = {
   zcash: {
@@ -17,5 +21,123 @@ export const configs: Record<string, ProtocolConfig> = {
       "https://zcash.readthedocs.io/en/latest/",
       "https://zcash.github.io/",
     ],
+  },
+  worm: {
+    id: "worm",
+    title: "WORM",
+    description:
+      "The WORM is an ERC-20 token which is minted via the process of burning Ethereum (ETH) by sending it to unclaimable addresses. Users generate a proof-of-burn receipt which enables the minting of WORM. ETH transfers sent to an unclaimable address are indistinguishable from a regular ETH transfer to a fresh address. There is no way for an outside observer to detect whether a user is interacting with the WORM protocol. The protocol is based on EIP-7503, which standardizes Private Proof-of-Burn. The protocol introduces per-block emission limits to cap WORM token inflation.",
+    documentation: "https://github.com/worm-privacy/whitepaper",
+    categories: ["zkWormholes"],
+    sourceUrls: [
+      "https://github.com/worm-privacy/whitepaper",
+      "https://eips.ethereum.org/EIPS/eip-7503",
+      "https://github.com/worm-privacy/proof-of-burn",
+      "https://github.com/worm-privacy/worm",
+      "https://github.com/worm-privacy/miner",
+    ],
+    context:
+      "CRITICAL: WORM is an APPLICATION-LAYER smart contract protocol deployed on Ethereum mainnet. " +
+      "It is NOT the same as EIP-7503. EIP-7503 proposes a consensus-layer change to Ethereum (a new " +
+      "transaction type that mints native ETH). WORM instead implements the proof-of-burn concept " +
+      "entirely at the app layer using deployed smart contracts — no Ethereum client changes are needed. " +
+      "WORM has two tokens: BETH (an ERC-20 proof-of-burn receipt, 1:1 with burned ETH) and WORM " +
+      "(a scarce ERC-20 minted from BETH at 50 per 30-minute epoch). The contracts are deployed on " +
+      "Ethereum mainnet (BETH: 0x5624344235607940d4d4EE76Bf8817d403EB9Cf8, WORM: " +
+      "0xfC9d98CdB3529F32cD7fb02d175547641e145B29). The proof-of-burn uses Circom circuits with " +
+      "Poseidon2 hashing (not SHA256), Keccak256 for PoW, and Merkle-Patricia-Trie state proofs. " +
+      "Do NOT describe EIP-7503 mechanisms (new tx types, SSTORE at WORMHOLE_NULLIFIER_ADDRESS, " +
+      "consensus-level minting of native ETH) as if they apply to WORM. Use the EIP only for " +
+      "additional reading and background context on the proof-of-burn concept. Always prefer the " +
+      "WORM whitepaper and GitHub repos as primary sources.",
+  },
+  zerc20: {
+    id: "zerc20",
+    title: "zERC20",
+    description:
+      'zERC20 is a fully ERC-20 compliant crosschain private transfer token. Users can perform private transfers directly from standard wallets like MetaMask—no special software required. From an external observer\'s perspective, private transfers are indistinguishable from regular transfers.ERC-20 Compatible: Works with any wallet, DEX, or DeFi protocol that supports standard ERC-20 tokens. Private Transfers: Send tokens without revealing the link between sender and recipient addresses Crosschain Support: Transfer privately across multiple blockchains via LayerZero. No Special Wallet Required: Use MetaMask or any standard Ethereum wallet. It works by A temporary "burn address" is cryptographically generated. The sender transfers zERC20 to this burn address (the tokens are effectively burned). The recipient withdraws the same amount to any address using a zero-knowledge proof. The link between the burn address and the withdrawal address is never revealed on-chain.',
+    documentation: "https://zerc20.gitbook.io/zerc20",
+    categories: ["zkWormholes"],
+    sourceUrls: ["https://zerc20.gitbook.io/zerc20"],
+  },
+  curvy: {
+    id: "curvy",
+    title: "Curvy",
+    description:
+      "Curvy is a privacy-preserving cross-chain payment protocol with compliance features. It combines stealth addressses with ZK-SNARKs",
+    documentation: "https://docs.curvy.box/",
+    categories: ["Stealth addresses"],
+    sourceUrls: [
+      "https://docs.curvy.box/",
+      "https://docs.curvy.box/for-the-curious/",
+      "https://docs.curvy.box/for-the-curious/walkthroughs/receiving-funds-privately",
+      "https://docs.curvy.box/for-the-curious/walkthroughs/sending-funds-privately",
+      "https://docs.curvy.box/for-the-curious/walkthroughs/unshielding-funds-privately",
+      "https://docs.curvy.box/for-the-curious/privacy-model.html",
+      "https://docs.curvy.box/for-the-curious/compliance-model.html",
+      "https://docs.curvy.box/for-the-curious/building-blocks/",
+      "https://github.com/0xCurvy/contracts",
+      "https://docs.curvy.box/faq.html",
+    ],
+  },
+  nullmask: {
+    id: "nullmask",
+    title: "Nullmask",
+    description:
+      "Nullmask is a privacy layer that sits between an ordinary wallet (e.g. MetaMask) and a chain via a custom RPC proxy. Users sign a single authorization message to derive viewing, nullifying and encryption keys; the proxy converts a user's normal transactions into shielded UTXO-style 'Notes' and produces UltraHonk zk-SNARK proofs (~2s) for deposits, transfers and withdrawals. Shielded state is represented as encrypted notes on-chain alongside a key registry; users trial-decrypt notes to find their own. Retroactive compliance allows flagged deposits to be revoked.",
+    documentation: "https://nmskdiagram.vercel.app/",
+    categories: ["VPN (Private Intents)"],
+    sourceUrls: [
+      "https://nullmask.io/",
+      "https://nmskdiagram.vercel.app/",
+      "https://hackmd.io/@krnak/Sy5zROAFWx",
+      "https://hackmd.io/@krnak/r1W6uGUsZe",
+    ],
+  },
+  houdiniswap: {
+    id: "houdiniswap",
+    title: "Houdini Swap",
+    description:
+      "Houdini Swap is a non-custodial cross-chain liquidity aggregator that obtains privacy by routing each swap through two independent off-chain CEX partners and three separate blockchains, so no single counterparty sees the full path from source to destination. It is not a mixer: liquidity is not pooled and no zero-knowledge proofs are used; privacy comes from partitioning knowledge across routing hops. The service aggregates DEXes and bridges across 100+ chains and curates CEX partners that run industry-standard AML programmes.",
+    documentation: "https://docs.houdiniswap.com/",
+    categories: ["Cross-L1 CEX aggregator and mixer"],
+    sourceUrls: [
+      "https://docs.houdiniswap.com/overview/getting-started/what-is-houdini",
+      "https://docs.houdiniswap.com/overview/getting-started/core-swap-concepts",
+      "https://docs.houdiniswap.com/overview/getting-started/privacy-and-compliance",
+      "https://docs.houdiniswap.com/overview/swaps-and-transfers/private-swaps",
+      "https://docs.houdiniswap.com/overview/coverage-and-economy/chain-tokens-partners",
+      "https://docs.houdiniswap.com/overview/coverage-and-economy/monetization-and-fees",
+      "https://docs.houdiniswap.com/developer-hub/overview/architecture",
+      "https://docs.houdiniswap.com/developer-hub/core-concepts/routing-types",
+      "https://docs.houdiniswap.com/products/swap-transfer/compliance-policy",
+    ],
+    context:
+      "Houdini Swap is explicitly NOT a mixer and NOT a zero-knowledge privacy protocol. Its privacy model is 'knowledge partitioning across off-chain CEX hops and multiple blockchains': two non-custodial CEX partners and three blockchains are used so no single party sees the full source-to-destination path. Do not describe Houdini as a shielded pool, ZK rollup, or anonymity-set protocol. There are no on-chain privacy contracts, no notes, and no nullifiers — routing and compliance happen off-chain via CEX partners and a proprietary routing engine.",
+  },
+  mirage: {
+    id: "mirage",
+    title: "Mirage",
+    description:
+      "Mirage is a privacy layer for stablecoin transfers on Ethereum L1 that makes private transactions indistinguishable from ordinary onchain activity. It avoids shared pools by using per-transaction escrow contracts whose EVM bytecode is obfuscated by Azoth, an open-source Rust obfuscator that produces many deterministic variants of the same contract logic. Execution is carried out by a decentralised set of Nomad operator nodes that post bonds into the escrow and earn rewards for settling transfers. The protocol is currently in closed alpha with a public test environment in preparation.",
+    documentation: "https://docs.mirageprivacy.com/",
+    categories: ["EVM Obfuscators"],
+    sourceUrls: [
+      "https://docs.mirageprivacy.com/understanding-mirage/introduction",
+      "https://docs.mirageprivacy.com/understanding-mirage/how-mirage-compares",
+      "https://docs.mirageprivacy.com/understanding-mirage/the-undetectability-challenge",
+      "https://docs.mirageprivacy.com/understanding-mirage/a-simple-example",
+      "https://docs.mirageprivacy.com/azoth/introduction/",
+      "https://docs.mirageprivacy.com/nomad/overview/",
+      "https://docs.mirageprivacy.com/faq/general",
+      "https://docs.mirageprivacy.com/faq/compliance",
+      "https://docs.mirageprivacy.com/faq/technical",
+      "https://blog.mirageprivacy.com/posts/introducing-mirage",
+      "https://blog.mirageprivacy.com/posts/introducing-azoth",
+      "https://github.com/MiragePrivacy/azoth",
+      "https://github.com/MiragePrivacy/escrow",
+    ],
+    context:
+      "Mirage's privacy model is NOT a shielded pool, mixer, or ZK rollup. It avoids pooled funds entirely. Each private transfer deploys a transaction-specific escrow contract; Azoth obfuscates the bytecode so the contract is indistinguishable from any other unverified deployment. A decentralised Nomad network settles transfers against the escrow using time-bonded execution. As of April 2026 the protocol is in closed alpha, with a public test environment in preparation — do not report it as mainnet-live. SGX is used by Nomad operators for node-side key handling.",
   },
 };

--- a/project-evaluations/scripts/research-prompts.ts
+++ b/project-evaluations/scripts/research-prompts.ts
@@ -1,86 +1,115 @@
 import type { PropertyContent } from "../src/types.js";
 
-// prettier-ignore
-const BASE_PROMPT = (
-  property: PropertyContent,
-  protocolName: string,
-) => `You are a technical researcher evaluating privacy protocols for an objective report
-  called "The State of Private Transfers 2026". The report is a comprehensive analysis of the state of
-  private transfers, including the current landscape, the challenges and opportunities, and the future
-  of private transfers.
-
-  Evaluate the "${property.name}" property for ${protocolName}.
-
-  Property definition: ${property.description}
-  Metric: ${property.metric}
-  Input type: ${property.inputType}
-
-  ${property.options ? `Allowed values: ${property.options.join(" / ")}` : `Expected format: ${property.metric}`}`;
-
-// prettier-ignore
-const BASE_RULES = `
-  GENERAL RULES:
-  1. Start your answer by directly addressing the property. Your first sentence must answer the question.
-  2. Every sentence must be relevant to the property being evaluated. Do not include general descriptions of the protocol, its history, or features unrelated to this specific property.
-  3. Prioritize information density. Every sentence should deliver a concrete fact.
-  4. Only state facts you are highly confident about.
-  5. If uncertain about a claim, omit it rather than guess. Never invent statistics, percentages, or quotes.
-  6. Distinguish current live features from planned/future ones. Future features must NOT influence the value chosen.
-  7. Never use these phrases: "the document", "prior research", "the provided documentation", "indicates", "confirms", "the prior research confirms", "the prior research found". Write as if you are the expert, not reading a source.
-  8. Never say "since X, the answer is Y". Just state the answer and explain why.
-  9. Write technically but naturally — not robotic. Avoid marketing language (e.g. "banks", "your money", "advanced applied cryptography", "enhanced privacy", "cutting-edge", "innovative", "first practical application of").
-  10. Do not reference PRs, config files, variable names, lines of code, or implementation details. Focus on protocol-level facts. You CAN reference technical standards and primitives (e.g. BIP32, BFT, zk-SNARKs, viewing keys, nullifier sets, commitment trees) — aim for a technical assessment, not a code review.
-  11. Do not reference ZIP/EIP/BIP numbers, improvement proposal processes, or governance token mechanics unless the property is specifically about governance or upgradeability. You may mention that a feature is proposed or in development without naming the specific proposal.
-  12. For properties with opt-in privacy (e.g. shielded vs transparent): if the privacy feature exists and is usable, the answer is Yes. Opt-in privacy still counts.
-  13. Only cite text that directly proves or disproves the specific property being evaluated. Do not cite general protocol descriptions, feature overviews, or related but tangential information.
-
-  PROPERTY GUIDANCE RULES:
-  14. For compliance properties: consensus-level validation on permissionless blockchains is NOT compliance enforcement. Compliance means active restriction or filtering by an entity.
-  15. For cryptographic verifiability: mathematical proofs verify correctness, separate from consensus.
-  16. For Open Source: find a page that explicitly states the license type (MIT, Apache 2.0, etc.). Prefer official project websites or license pages over GitHub READMEs. Do not mention repository files (e.g. COPYING, LICENSE), GitHub structure, forks, or derived-from relationships.
-  17. For Deposit time / Withdraw time: For L1 protocols without a distinct deposit/withdraw concept, use N/A.
-  18. For Escape hatch: For standalone L1 blockchains where funds are native to the chain, this may be N/A.
-  19. For Asset privacy: For single-asset protocols (e.g. a chain with only one native currency), use No.
-  20. For Censorship resistance: if the protocol is permissionless and any valid transaction can eventually be included (even if individual miners/validators can soft-censor), the answer is Yes. Soft censorship by some participants does not make the protocol censorship-susceptible if others can still include the transaction. If the protocol uses relayers or broadcasters, mention their role in the description. Relayer dependence alone does not make the protocol censorship-susceptible if users can bypass relayers and interact with the underlying contracts directly.
-
-  SOURCE SELECTION RULES:
-  21. The page must contain specific technical content about this property — not just a table of contents, navigation page, or landing page.
-  22. Do NOT return PDF URLs — they cannot be processed. Find an HTML alternative.
-  23. Never use blog posts from exchanges, trading platforms, or non-official sources. Only use blog posts from the protocol's own team or foundation (e.g. electriccoin.co/blog for Zcash, blog.ethereum.org for Ethereum). Prefer official docs, specs, or project websites over any blog.
-  24. If the best source is a PDF, search for an HTML version of the same content.
-
-  ADDITIONAL PROPERTY RULES:
-  25. For Number of secrets: the value should count only independently stored secrets. If all keys (spending, viewing, encryption) are deterministically derived from one wallet signature or mnemonic, the answer is 1. The notes MUST list all keys the protocol uses, how each is derived, and what cryptographic primitives are used (curves, hash functions, key derivation schemes).
-  26. For Time-to-finality (apps/L2s/L3s): should be N/A if the protocol is deployed on other blockchains and inherits their finality. List all deployed networks. Exception: L3s may have their own finality time if their settlement adds delay beyond the underlying L2.
-  27. For Cryptographic verifiability (L1s): transaction correctness can be cryptographically verified (zk-SNARKs, ring signatures, etc.) while consensus uses PoW/PoS (majority-based). Note this distinction. For protocols with additional trust assumptions (upgradable contracts, permissioned gates), the answer may be No even if the proof system is sound.
-  28. For Open source: must state the specific license (MIT, BSD 3-Clause, GPL-3.0, Unlicense, etc.). Check ALL key repositories — contracts, circuits, SDKs may have different licenses. If any critical component (e.g. ZK circuits) has no license or is "source-available" only, the answer is No.
-  29. For Plausible deniability: this property asks whether private transfers are indistinguishable from public transfers. For privacy-by-default protocols (e.g. Monero), the answer is No because the entire protocol is a known privacy chain — a user cannot plausibly deny to an exchange or regulator that privacy features are being used. Plausible deniability requires private transactions to be embedded within or indistinguishable from non-private ones (e.g. zkWormholes). For opt-in privacy protocols, plausible deniability is also No because shielded transactions are distinguishable from transparent ones.
-  30. For Relayers/Broadcasters: if a protocol uses relayers, mention this in Censorship resistance notes but do not change the value to No if users can interact with contracts directly. Mention in External network dependence but mark as No if the relayer is optional.
-  31. Do not use library names in notes (e.g. "plonky2_bn254", "plonky2_keccak"). Use cryptographic primitive names instead (e.g. "BN254 curve", "Keccak hashing").
-  32. Do not restate the value as a conclusion at the end of notes (e.g. "Therefore the answer is Yes" or "Therefore there are 2 secrets").`;
+/**
+ * Single source of truth for evaluation rules.
+ *
+ * Rules are grouped by the flow that consumes them. Anything written or reviewed
+ * goes through this file.
+ *
+ *   WRITING_RULES          — used by the citations prompt and by the review skill.
+ *   CROSS_CHECK_RULES      — consistency checks; used by the citations prompt and by review.
+ *   VALUE_FORMAT_RULES     — schema enum + JSON shape; used by the citations prompt and by review.
+ *   SOURCE_SELECTION_RULES — used by the /research-sources skill when discovering URLs,
+ *                            and by review when verifying URL suitability.
+ *   REVIEW_ONLY_RULES      — only used by the /review-evaluation skill (not injected into
+ *                            the citations prompt — they describe post-hoc verification).
+ *   PROPERTY_RULES         — per-property guidance, keyed by property name exactly as in
+ *                            schema.ts. The citation prompt, /research-sources, and
+ *                            /review-evaluation all look these up when the property applies.
+ *
+ * Skills that need to read rules should load this file directly with the Read tool.
+ */
 
 // prettier-ignore
-export function buildResearchPrompt(
-  property: PropertyContent,
-  protocolName: string,
-  sourceUrls?: string[],
-  triedUrls: string[] = [],
-): string {
-  return `
-    ${BASE_PROMPT(property, protocolName)}
+export const WRITING_RULES = `
+WRITING RULES:
+1. Start your answer by directly addressing the property. The first sentence must answer the question.
+2. Every sentence must be relevant to the property being evaluated. Do not include general descriptions of the protocol, its history, or unrelated features.
+3. Prioritise information density. Every sentence should deliver a concrete fact.
+4. Only state facts you are highly confident about. If uncertain, omit rather than guess. Never invent statistics, percentages, or quotes.
+5. Distinguish current live features from planned/future ones. Future or "upcoming" features must not influence the chosen value; mention them in notes only if clearly marked as planned.
+6. Never use "the document", "prior research", "the provided documentation", "indicates", or "confirms". Write as the expert, not as someone summarising a source.
+7. Do not restate the value as a conclusion at the end of notes (e.g. "Therefore the answer is Yes", "In conclusion...", "Since X, the answer is Y"). The value field already captures the answer — notes explain reasoning.
+8. Avoid marketing language ("banks", "your money", "advanced applied cryptography", "enhanced privacy", "cutting-edge", "innovative", "first practical application of").
+9. Do not reference implementation artefacts — PRs, config files, variable names, line numbers, code identifiers, or proposal numbers (ZIP/EIP/BIP) unless the property is specifically about governance or upgradeability. Technical standards and primitives (BIP-32, BFT, zk-SNARKs, viewing keys, nullifier sets) are fine. You may mention a feature is proposed without naming the proposal.
+10. Cite only text that directly proves or disproves the specific property. Do not cite general protocol descriptions or tangential information.
+11. Do not copy long runs of source text. Whole sentences or multi-clause passages lifted verbatim must be reworded. Matching short phrases (up to ~10 words) to the source is fine and expected — citations attach to text that shares wording with the document, so do not rewrite naturally-phrased grounded statements just to avoid overlap.
+12. Rewrite branded or capitalised terminology from protocol docs (e.g. "Private Balances", "Relay Adapt", "Shielded Pool") as lowercase generic equivalents ("private balances", "shielded pool") unless it is a proper noun. This applies even though short-phrase overlap with the source is otherwise fine — the goal is expert-voice neutrality, and citations still attach to the underlying paraphrase.
+13. When a property involves cryptography, name standard primitives — proof system (Groth16, Plonky2, Halo2), curve (BN254, Baby Jubjub, Curve25519), signature (ECDSA, EdDSA, Schnorr), hash (Poseidon, Pedersen, MiMC), key derivation (BIP-32, ECDH). Do not use library names (e.g. "plonky2_bn254" → "BN254 curve"). Do not include raw derivation paths — name the standard instead.
+14. Use correct English grammar and spelling. Prefer gender-neutral pronouns (their/they/them). "Sent" is the past tense of "send". Check subject-verb agreement and typos.
+15. For opt-in privacy (e.g. shielded vs transparent), if the privacy feature exists and is usable, the answer is Yes.`;
 
-    Hint: ${sourceUrls?.length
-      ? "Suggested starting points for research:\n" + sourceUrls.map((u) => `- ${u}`).join("\n")
-      : "The latest documentation is a good place to start, but you should expand your search beyond this"}
+// prettier-ignore
+export const CROSS_CHECK_RULES = `
+CROSS-CHECK RULES:
+1. Compliance cross-check: the four compliance properties must be internally consistent. If "Type of compliance" = ["None"], then "Layer of enforcement" = "None", "Point of enforcement" = ["None"], and "Enforcement entities" = "None". If any of the four is non-None, all four must describe the same mechanism. Carveout: "Selective disclosure" is user-discretionary rather than entity-enforced, so when Type of compliance = ["Selective disclosure"] alone (no other policy), Layer / Entities / Point may all stay None — there is no entity enforcing voluntary key sharing at any point. The carveout does not apply if Selective disclosure is combined with another Type value, in which case the quartet must align around that other mechanism.
+2. Compliance vs protocol rules: consensus-level validation and protocol-level proof verification on permissionless blockchains are NOT compliance. Compliance means active restriction or filtering by an entity — blocklists, allowlists, KYC gates, sanctions screening. Do not use proof verification, nullifier uniqueness, or issuance caps to justify a non-None Layer of enforcement.
+3. Viewing-key cross-check: if "Selective disclosure: viewing entity" = ["None"], then "Selective disclosure: viewing control" = "None". A non-"None" viewing control requires that a viewing mechanism actually exists.
+4. Multi-select contradictions: do not mix a concrete value with "None" (e.g. ["Selective disclosure", "None"] is invalid). If a mechanism exists, "None" must not also be selected.
+5. Contract-level compliance audit: when a protocol is implemented as smart contracts, inspect the contract repository for (a) proxy patterns → Upgradeability ≠ Immutable; (b) onlyOwner / onlyRole gates → Enforcement entities ≠ None; (c) blocklist / allowlist hooks in _update, _beforeTokenTransfer, or transfer functions → Type of compliance includes the policy, Point of enforcement includes each path the hook runs in. Do not rely on whitepapers alone for these four properties.
+6. The compliance quartet (Layer of enforcement, Enforcement entities, Type of compliance, Point of enforcement) must reflect compliance mechanisms that are currently live on the canonical protocol. Do not include documented future or "upcoming Beta" features. If the live protocol has no active compliance gate, all four must be None / ["None"], even if the roadmap adds KYT, wallet screening, or blocklists later — describe the planned features in notes instead.`;
 
-    ${triedUrls.length > 0
-      ? "Do NOT use these URLs (already tried means there is insufficient content):\n" + triedUrls.map((u) => `- ${u}`).join("\n")
-      : ""}
+// prettier-ignore
+export const VALUE_FORMAT_RULES = `
+VALUE FORMAT RULES:
+1. Before writing any note claiming mainnet deployment, verify against the canonical deployment source (testnet README, deployment artifacts, block explorer). An incentivised-testnet deployment is not mainnet.
+2. Do not embed deployed contract addresses, transaction hashes, or chain IDs in notes. Deployment status ("Sepolia testnet", "Ethereum mainnet") is acceptable — the forbidden part is the literal hex address, unless it is a canonical singleton that is a security-relevant invariant of the protocol.
+3. Off-chain-only services (routing aggregators, custodial-style services without protocol contracts) still need a value from the enum for Upgradeability, Private state model, Private Data Storage, and Private State Scalability. Pick the closest option, and in notes state plainly that the property does not really apply because the service has no on-chain protocol contracts / no private state. Do not invent pseudo-commitments or host-chain properties to justify a value.
+`;
 
-    ${BASE_RULES}
+// prettier-ignore
+export const SOURCE_SELECTION_RULES = `
+SOURCE SELECTION RULES:
+1. The page must contain specific technical content about the property — not a table of contents, navigation page, or landing page.
+2. Do not use PDF URLs — they cannot be processed. If the best source is a PDF, search for an HTML version of the same content.
+3. Never use blog posts from exchanges, trading platforms, or non-official sources. Only blog posts from the protocol's own team or foundation. Prefer official docs, specs, or project websites over any blog.
+4. URLs should point to specific pages, not docs landing pages. GitHub organisation roots (github.com/org) are acceptable for Open source properties. Individual repository roots should point to README or LICENSE where possible.`;
 
-    Search the web for the most authoritative source page for this property.
-    Respond with ONLY a JSON object: {"url": "best_source_url", "summary": "what you found"}`;
+// prettier-ignore
+export const REVIEW_ONLY_RULES = `
+REVIEW-ONLY RULES:
+1. Fetch every URL attached to a property and verify the notes and value are consistent with the page content. Flag dead URLs or cases where the page does not support the claim.
+2. For any "TODO" in notes or values, web search for an answer. If a high-confidence answer is available from an authoritative source, propose replacing the TODO with it and cite the source. Otherwise leave the TODO and record it as "TODO: unresolved — needs manual research". Never guess.
+3. Flag properties where notes say "we assume" or "we could assume".
+4. Flag notes that describe a mechanism without answering the property question (e.g. describing cross-contract calls without stating whether this means DeFi access, or describing key derivation without stating how many independent secrets exist) as "notes explain how but not what".
+5. For L2/L3 protocols, consult L2BEAT (https://l2beat.com/scaling/projects/{protocol}) as a primary reference for upgradeability, escape hatch, operator permissions, and finality, alongside protocol docs.
+6. Preserve citations; prefer the smallest edit. The end state across the evaluation should be: most properties retain their citations[] array from Phase B; only a few carry "needsResearchReview": true. Reword only the sentences that violate a rule and drop individual citations[] entries whose cited_text no longer supports the corrected prose; keep every citation whose cited_text still substantiates what the notes now say. Rewrite from scratch only when every existing citation has been invalidated.
+7. Flag and record the source. Whenever review changes a property's value or notes, set "needsResearchReview": true AND write the URL that verified the correction into the property's "url" field. If multiple URLs were used, pick the one that most directly substantiates the corrected claim. Purely editorial rewording (no new evidence) still needs the flag but may omit "url". A property may omit "needsResearchReview" only when its notes and value survive review unchanged AND every attached citation still substantiates the text.`;
+
+// prettier-ignore
+export const PROPERTY_RULES: Record<string, string> = {
+  "Confidentiality":
+    "For protocols that use standard ERC-20 (or any unmodified public-ledger token) as the user-facing balance, the value is No. The token contract leaks per-address balances and transfer amounts regardless of how private movement between addresses is.",
+  "Asset privacy":
+    "For single-asset protocols (e.g. a chain with only one native currency, or a single wrapped token per asset), the value is No.",
+  "Plausible deniability":
+    'This property asks whether the act of *entering* the privacy protocol is indistinguishable from an ordinary public transfer. zkWormhole protocols (e.g. WORM, zERC20) are Yes: the deposit/burn is a standard EOA-to-EOA or ERC-20 transfer to a cryptographically-derived address, which cannot be distinguished on-chain from a normal transfer. A user who only deposits never touches a privacy-specific contract and therefore has deniability. For privacy-by-default protocols (e.g. Monero) the answer is No — the entire chain is a known privacy system. For opt-in shielded-pool protocols (e.g. Railgun, Tornado Cash) the answer is No because the deposit itself calls a known privacy contract. When the answer is Yes, notes MUST state explicitly that deniability covers deposit/entry only and does not extend to withdraw/mint, since the withdraw step is a visible interaction with the verifier.',
+  "Deposit time":
+    "For L1 protocols without a distinct deposit concept, use N/A.",
+  "Withdraw time":
+    "For L1 protocols without a distinct withdraw concept, use N/A.",
+  "Time-to-finality":
+    "For apps and L2s deployed on other blockchains, the value is N/A and finality is inherited from the underlying chain. List the deployed networks in the notes. Exception: L3s may have their own finality time if their settlement adds delay beyond the underlying L2.",
+  "Escape hatch":
+    "For standalone L1 blockchains where funds are native to the chain, the value may be N/A. For routing or aggregator services that never hold funds in a protocol-controlled pool (e.g. cross-chain CEX aggregators), the value is N/A because there is no pool to exit from — partner-level customer-service recovery is not a protocol-level escape hatch.",
+  "Censorship resistance":
+    "If the protocol is permissionless and any valid transaction can eventually be included (even if individual miners or validators soft-censor), the value is Yes. Relayer or broadcaster dependence alone does not make the protocol censorship-susceptible if users can bypass relayers and interact with contracts directly. Mention relayer roles in the notes.",
+    "Number of secrets":
+      "Count only independently stored secrets. If all keys (spending, viewing, encryption) are deterministically derived from one wallet signature or mnemonic, the value is 1. The minimum is 1 whenever the user must sign anything to use the protocol — even when the protocol derives no keys of its own and the user just signs with their pre-existing Ethereum wallet, the wallet key is the one secret in use. Never emit 0. Notes MUST list every key, how each is derived, and the cryptographic primitives used.",
+  "Cryptographic verifiability":
+    'Yes when transaction correctness is enforced by cryptographic proof verification (zk-SNARKs, ring signatures, signature schemes) that an external observer can re-check against the math given the published verifier. Use "Yes, with L1 consensus" for L1 blockchains where individual transaction correctness is cryptographic but ordering/inclusion is consensus-based (PoW/PoS majority). No when correctness rests on an economic mechanism (stake-slashing not tied to a math proof), a social mechanism (multisig vote, governance signoff), or a hardware-trust mechanism (TEE/SGX attestation, where trust roots in a hardware vendor signing CA rather than pure math). Upgradeable verifier contracts and permissioned admin gates are NOT a reason to mark No here — those are separately captured by Upgradeability and Censorship resistance. Notes should still mention if the verifier is swappable so readers see the full picture.',
+  "Open source":
+    'Value "Yes" requires an OSI-approved license: MIT, Apache-2.0, any GPL-family, any BSD-family, ISC, MPL, or Unlicense. Source-available licenses (BSL, Commons Clause, SSPL, Elastic License, "no-commercial", or no license) are No. A BSL change-date to a future open-source license does NOT make the protocol open source today. Check ALL critical repositories — contracts, circuits, SDKs may have different licenses; if any critical component is source-available only, value is No. Name the specific license in notes.',
+  "Upgradeability":
+    "Evaluate protocol-level upgrade authority, not just individual on-chain artefacts. If a central team can revoke operators, swap the toolchain that produces contracts (e.g. a bytecode obfuscator), sign the binaries that executors must run, or ship a successor contract that users are effectively forced to migrate to, the value is Single admin (or Multi-sig / DAO depending on who holds the keys) even if each deployed contract instance is immutable after deployment. Immutable is only correct when there is no central party capable of changing protocol behaviour across future transfers.",
+};
+
+/** Rules assembled into the citations prompt for a given property. */
+function citationRulesFor(property: PropertyContent): string {
+  const perProperty = PROPERTY_RULES[property.name];
+  const blocks = [WRITING_RULES, CROSS_CHECK_RULES, VALUE_FORMAT_RULES];
+  if (perProperty) blocks.push(`PROPERTY-SPECIFIC RULE (${property.name}):\n${perProperty}`);
+  return blocks.join("\n");
 }
 
 // prettier-ignore
@@ -88,18 +117,28 @@ export function buildEvaluationPrompt(
   property: PropertyContent,
   protocolName: string,
   researchSummary: string,
+  context?: string,
 ): string {
+  const allowed = property.options
+    ? `Allowed values: ${property.options.join(" / ")}`
+    : `Expected format: ${property.metric}`;
   return `
-    ${BASE_PROMPT(property, protocolName)}
+    You are a technical researcher evaluating privacy protocols for an objective report
+    called "The State of Private Transfers 2026".
+
+    Evaluate the "${property.name}" property for ${protocolName}.
+
+    Property definition: ${property.description}
+    Input type: ${property.inputType}
+    ${allowed}
+
+    ${context ? `IMPORTANT CONTEXT:\n${context}\n` : ""}
 
     Prior research found: ${researchSummary}
 
-    ${BASE_RULES}
+    ${citationRulesFor(property)}
 
-    Then output a JSON object (no code fences):
-    - "value": matching one of the allowed options exactly
-    - "notes": your 2-4 sentence answer from above
-
-    IMPORTANT: If the input type is "multi-select", you MUST format the value as a JSON array string even for a single selection, e.g. ["Option1"]. Never output a plain string for multi-select fields.
-    If the property is a number or text, provide the value as a string.`;
+    How to respond — follow this order strictly:
+    1. FIRST, write your 2-4 sentence answer as natural prose BEFORE calling any tool. Ground each substantive claim in the provided document so citations attach automatically. Do NOT skip this step — the prose is where citations live; if you go straight to the tool call you lose all citation evidence.
+    2. THEN, call the record_evaluation tool exactly once. If the document does not support any answer, pass insufficient_data=true and omit value.`;
 }

--- a/project-evaluations/scripts/research-protocol.ts
+++ b/project-evaluations/scripts/research-protocol.ts
@@ -1,8 +1,9 @@
 import "dotenv/config";
 import Anthropic from "@anthropic-ai/sdk";
+import { existsSync, readFileSync } from "fs";
 import { PROPERTY_DEFINITIONS } from "../src/data/schema.js";
 import type { Property, PropertyContent } from "../src/types.js";
-import { buildResearchPrompt, buildEvaluationPrompt } from "./research-prompts.js";
+import { buildEvaluationPrompt } from "./research-prompts.js";
 import { type ProtocolConfig } from "./research-config.js";
 
 const SKIP_PROPERTIES = new Set([
@@ -12,9 +13,37 @@ const SKIP_PROPERTIES = new Set([
   "On-chain gas cost: withdraw",
 ]);
 
-/** Loop through property definitions, skip/keep as needed, and evaluate each. */
+type CacheEntry = { name: string; url: string; summary: string };
+type ResearchCache = { id: string; generatedAt: string; properties: CacheEntry[] };
+
+export function loadResearchCache(protocolId: string): ResearchCache {
+  const cachePath = new URL(`./research-cache/${protocolId}.json`, import.meta.url);
+  if (!existsSync(cachePath)) {
+    throw new Error(
+      `Research cache missing at ${cachePath.pathname}.\n` +
+        `Run /research-sources ${protocolId} in Claude Code to populate it before invoking this script.`,
+    );
+  }
+  return JSON.parse(readFileSync(cachePath, "utf-8"));
+}
+
 export async function evaluateProperties(config: ProtocolConfig, existingProperties: Property[], only: string[]) {
   const client = new Anthropic();
+  const cache = loadResearchCache(config.id);
+  const cacheByName = new Map(cache.properties.map((entry) => [entry.name, entry]));
+
+  const targetedUrls = cache.properties
+    .filter((entry) => only.length === 0 || only.includes(entry.name))
+    .map((entry) => entry.url);
+  const uniqueUrls = Array.from(new Set(targetedUrls));
+  const fetchedByUrl = new Map<string, { text: string; sourceUrl: string }>();
+  await Promise.all(
+    uniqueUrls.map(async (url) => {
+      const fetched = await fetchTextFromUrl(url);
+      if (fetched) fetchedByUrl.set(url, fetched);
+      else console.warn(`warn: failed to fetch ${url} — properties citing it will be INSUFFICIENT_DATA`);
+    }),
+  );
 
   const properties: Property[] = [];
   let okCount = 0;
@@ -30,20 +59,31 @@ export async function evaluateProperties(config: ProtocolConfig, existingPropert
       continue;
     }
 
-    console.log(`Analysing ${propertyDefinition.name}`);
-    let property: Property = { name: propertyDefinition.name, value: "INSUFFICIENT_DATA" };
-    const triedUrls: string[] = [];
+    const cached = cacheByName.get(propertyDefinition.name);
+    if (!cached) {
+      throw new Error(
+        `Research cache is missing an entry for "${propertyDefinition.name}". ` +
+          `Rerun /research-sources ${config.id} --only "${propertyDefinition.name}" to populate it.`,
+      );
+    }
 
-    for (let attempt = 0; attempt < 3; attempt++) {
-      try {
-        const { url, summary } = await researchProperty(client, propertyDefinition, config, triedUrls);
-        triedUrls.push(url);
-        console.log(`source: ${url}${attempt > 0 ? ` (retry ${attempt})` : ""}`);
-        property = await evaluateWithCitations(client, propertyDefinition, config.title, url, summary);
-        if (property.value !== "INSUFFICIENT_DATA") break;
-      } catch (err) {
-        console.log(`retry: ${err instanceof Error ? err.message : err}`);
-      }
+    console.log(`Analysing ${propertyDefinition.name}`);
+    console.log(`source: ${cached.url}`);
+
+    let property: Property = { name: propertyDefinition.name, value: "INSUFFICIENT_DATA" };
+    try {
+      const fetched = fetchedByUrl.get(cached.url);
+      if (!fetched) throw new Error(`Failed to fetch ${cached.url}`);
+      property = await evaluateWithCitations(
+        client,
+        propertyDefinition,
+        config.title,
+        fetched,
+        cached.summary,
+        config.context,
+      );
+    } catch (err) {
+      console.log(`error: ${err instanceof Error ? err.message : err}`);
     }
 
     if (property.value && property.value !== "INSUFFICIENT_DATA" && !property.citations?.length) {
@@ -59,53 +99,32 @@ export async function evaluateProperties(config: ProtocolConfig, existingPropert
   return properties;
 }
 
-/** Web search to find the best source URL and summary. */
-async function researchProperty(
-  client: Anthropic,
-  propertyDefinition: PropertyContent,
-  config: ProtocolConfig,
-  triedUrls: string[] = [],
-): Promise<{ url: string; summary: string }> {
-  const response = await client.messages.create({
-    model: "claude-sonnet-4-5",
-    max_tokens: 2048,
-    temperature: 0,
-    messages: [
-      { role: "user", content: buildResearchPrompt(propertyDefinition, config.title, config.sourceUrls, triedUrls) },
-    ],
-    tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3 }],
-  });
-
-  const text = response.content
-    .filter((b): b is Anthropic.TextBlock => b.type === "text")
-    .map((b) => b.text)
-    .join("");
-
-  const jsonMatch = text.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error("Malformed JSON in source research response");
-
-  const parsed = JSON.parse(jsonMatch[0]);
-  if (parsed.url?.endsWith(".pdf")) throw new Error(`PDF: ${parsed.url}`);
-  if (!parsed.url) throw new Error("No URL found");
-
-  return { url: parsed.url, summary: parsed.summary || "" };
-}
-
-/** Fetch source page, pass as citable document, return property with citations. */
 async function evaluateWithCitations(
   client: Anthropic,
   propertyDefinition: PropertyContent,
   protocolName: string,
-  sourceUrl: string,
+  fetched: { text: string; sourceUrl: string },
   researchSummary: string,
+  context?: string,
 ): Promise<Property> {
-  const fetched = await fetchTextFromUrl(sourceUrl);
-  if (!fetched) throw new Error(`Failed to fetch ${sourceUrl}`);
+  const tool: Anthropic.Tool = {
+    name: "record_evaluation",
+    description: "Record the final evaluation. Call exactly once after writing your prose answer.",
+    input_schema: {
+      type: "object",
+      properties: {
+        value: buildValueSchema(propertyDefinition),
+        insufficient_data: { type: "boolean" },
+      },
+      required: [],
+    },
+  };
 
   const response = await client.messages.create({
-    model: "claude-sonnet-4-5",
+    model: "claude-opus-4-7",
     max_tokens: 2048,
-    temperature: 0,
+    tools: [tool],
+    tool_choice: { type: "auto", disable_parallel_tool_use: true },
     messages: [
       {
         role: "user",
@@ -115,23 +134,39 @@ async function evaluateWithCitations(
             source: { type: "text", media_type: "text/plain", data: fetched.text },
             title: fetched.sourceUrl,
             citations: { enabled: true },
+            cache_control: { type: "ephemeral" },
           },
-          { type: "text", text: buildEvaluationPrompt(propertyDefinition, protocolName, researchSummary) },
+          { type: "text", text: buildEvaluationPrompt(propertyDefinition, protocolName, researchSummary, context) },
         ],
       },
     ],
   });
 
-  // Extract text and deduplicated char_location citations
+  const usage = response.usage;
+  console.log(
+    `cache: read=${usage.cache_read_input_tokens ?? 0} write=${usage.cache_creation_input_tokens ?? 0} miss=${usage.input_tokens}`,
+  );
+
+  if (process.env.DEBUG_RESEARCH) {
+    console.log("=== raw response.content ===");
+    console.log(JSON.stringify(response.content, null, 2));
+    console.log("=== end raw response.content ===");
+  }
+
   const textParts: string[] = [];
   const citations: NonNullable<Property["citations"]> = [];
   const seen = new Set<string>();
+  let toolInput: { value?: string; insufficient_data: boolean } | null = null;
 
   for (const block of response.content) {
+    if (block.type === "tool_use" && block.name === "record_evaluation") {
+      if (toolInput) throw new Error("Model called record_evaluation more than once");
+      toolInput = normalizeToolInput(block.input, propertyDefinition.options);
+      continue;
+    }
     if (block.type !== "text") continue;
     textParts.push(block.text);
-    if (!block.citations) continue;
-    for (const citation of block.citations) {
+    for (const citation of block.citations ?? []) {
       if (citation.type === "char_location" && !seen.has(citation.cited_text)) {
         seen.add(citation.cited_text);
         citations.push({
@@ -144,33 +179,44 @@ async function evaluateWithCitations(
     }
   }
 
-  // Parse JSON from response
-  const text = textParts.join("");
-  const jsonMatch = text.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) {
-    throw new Error("Malformed JSON in evaluation response");
-  }
-  if (text.includes("INSUFFICIENT_DATA")) {
+  if (!toolInput) throw new Error("Model did not call record_evaluation");
+  if (toolInput.insufficient_data || !toolInput.value) {
     return { name: propertyDefinition.name, value: "INSUFFICIENT_DATA" };
   }
 
-  let parsed: { value?: string; notes?: string };
-  try {
-    parsed = JSON.parse(jsonMatch[0]);
-  } catch {
-    return { name: propertyDefinition.name, value: "INSUFFICIENT_DATA" };
-  }
-
-  // Normalize multi-select: model outputs "Option" instead of ["Option"]
-  let value = String(parsed.value || "");
-  if (propertyDefinition.inputType === "multi-select" && !value.startsWith("[")) {
-    value = JSON.stringify([value]);
-  }
-
-  const property: Property = { name: propertyDefinition.name, value };
-  if (parsed.notes) property.notes = String(parsed.notes).replace(/<\/?cite[^>]*>/g, "");
+  const notes = textParts.join("\n").replace(/\s+/g, " ").trim();
+  const property: Property = { name: propertyDefinition.name, value: toolInput.value };
+  if (notes) property.notes = notes;
   if (citations.length > 0) property.citations = citations;
   return property;
+}
+
+function buildValueSchema(p: PropertyContent): Record<string, unknown> {
+  if (p.inputType === "multi-select") return { type: "array", items: { type: "string" } };
+  return { type: "string" };
+}
+
+function normalizeToolInput(
+  input: unknown,
+  options: readonly string[] | undefined,
+): { value?: string; insufficient_data: boolean } {
+  const raw = (input ?? {}) as Record<string, unknown>;
+  const insufficientData = raw.insufficient_data === true;
+  const rawValue = raw.value;
+
+  if (Array.isArray(rawValue)) {
+    const allStrings = rawValue.every((x) => typeof x === "string");
+    const allAllowed = !options || (allStrings && rawValue.every((x) => options.includes(x as string)));
+    return {
+      value: allStrings && allAllowed ? JSON.stringify(rawValue) : undefined,
+      insufficient_data: insufficientData,
+    };
+  }
+  if (typeof rawValue === "string") {
+    const allowed = !options || options.includes(rawValue);
+    return { value: allowed ? rawValue : undefined, insufficient_data: insufficientData };
+  }
+  return { value: undefined, insufficient_data: insufficientData };
 }
 
 /** Fetch a URL and strip to plain text. Returns null on failure. */
@@ -179,14 +225,16 @@ async function fetchTextFromUrl(url: string): Promise<{ text: string; sourceUrl:
     return fetchTextFromUrl(url.replace(/\.pdf$/, ".html"));
   }
 
-  // GitHub HTML pages are mostly navigation — fetch the raw markdown instead
   if (url.match(/^https:\/\/github\.com\/[^/]+\/[^/]+\/?$/)) {
-    const rawUrl = url.replace("github.com", "raw.githubusercontent.com") + "/master/README.md";
-    const response = await fetch(rawUrl).catch(() => null);
-    if (response?.ok) return { text: (await response.text()).replace(/<[^>]+>/g, "").trim(), sourceUrl: rawUrl };
+    const base = url.replace("github.com", "raw.githubusercontent.com").replace(/\/$/, "");
+    for (const branch of ["main", "master"]) {
+      const rawUrl = `${base}/${branch}/README.md`;
+      const response = await fetch(rawUrl, { signal: AbortSignal.timeout(15_000) }).catch(() => null);
+      if (response?.ok) return { text: (await response.text()).replace(/<[^>]+>/g, "").trim(), sourceUrl: rawUrl };
+    }
   }
 
-  const response = await fetch(url).catch(() => null);
+  const response = await fetch(url, { signal: AbortSignal.timeout(15_000) }).catch(() => null);
   if (!response?.ok) return null;
 
   const text = (await response.text())

--- a/project-evaluations/scripts/research-protocol.ts
+++ b/project-evaluations/scripts/research-protocol.ts
@@ -107,6 +107,10 @@ async function evaluateWithCitations(
   researchSummary: string,
   context?: string,
 ): Promise<Property> {
+  // We need two things back from Claude: a typed answer (e.g. "UTXO-based state model") AND citations.
+  //   - tool_use blocks give us a typed answer with no string parsing, but can't carry citations.
+  //   - text blocks can carry citations (when `citations.enabled` is on), but are free-form prose.
+  // So we ask for both: prose for the evidence, tool call for the answer, then stitch them together.
   const tool: Anthropic.Tool = {
     name: "record_evaluation",
     description: "Record the final evaluation. Call exactly once after writing your prose answer.",
@@ -120,6 +124,9 @@ async function evaluateWithCitations(
     },
   };
 
+  // Single API call that asks for BOTH prose (with citations) and a tool_use block.
+  // `citations: { enabled: true }` is what makes the API attach citations to text blocks.
+  // `disable_parallel_tool_use` ensures at most one tool_use block in the response.
   const response = await client.messages.create({
     model: "claude-opus-4-7",
     max_tokens: 2048,
@@ -147,23 +154,22 @@ async function evaluateWithCitations(
     `cache: read=${usage.cache_read_input_tokens ?? 0} write=${usage.cache_creation_input_tokens ?? 0} miss=${usage.input_tokens}`,
   );
 
-  if (process.env.DEBUG_RESEARCH) {
-    console.log("=== raw response.content ===");
-    console.log(JSON.stringify(response.content, null, 2));
-    console.log("=== end raw response.content ===");
-  }
-
+  // Response is a list of blocks. Sort each into the right bucket:
+  //   tool_use block  -> structured value (the "answer")
+  //   text block      -> prose + citations (the "evidence")
   const textParts: string[] = [];
   const citations: NonNullable<Property["citations"]> = [];
   const seen = new Set<string>();
   let toolInput: { value?: string; insufficient_data: boolean } | null = null;
 
   for (const block of response.content) {
+    // Bucket 1: the structured answer Claude put into the tool "slot".
     if (block.type === "tool_use" && block.name === "record_evaluation") {
       if (toolInput) throw new Error("Model called record_evaluation more than once");
       toolInput = normalizeToolInput(block.input, propertyDefinition.options);
       continue;
     }
+    // Bucket 2: the prose, and any citations the API attached to it.
     if (block.type !== "text") continue;
     textParts.push(block.text);
     for (const citation of block.citations ?? []) {
@@ -184,6 +190,7 @@ async function evaluateWithCitations(
     return { name: propertyDefinition.name, value: "INSUFFICIENT_DATA" };
   }
 
+  // Stitch the two buckets into one record: value from tool_use, notes+citations from text.
   const notes = textParts.join("\n").replace(/\s+/g, " ").trim();
   const property: Property = { name: propertyDefinition.name, value: toolInput.value };
   if (notes) property.notes = notes;

--- a/project-evaluations/src/data/schema.ts
+++ b/project-evaluations/src/data/schema.ts
@@ -60,8 +60,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
   {
     name: "Asset privacy",
     group: "Privacy",
-    description:
-      "Whether the specific asset being transferred is hidden from observers. For single-asset protocols, this is No since there is only one possible asset.",
+    description: "Whether the specific asset being transferred is hidden from observers.",
     metric: "Yes / No",
     inputType: "select",
     options: ["Yes", "No"],
@@ -101,8 +100,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
   {
     name: "Time-to-finality",
     group: "Cost and Performance",
-    description:
-      "The time it takes for a transaction to be considered irreversible (in seconds). For protocols deployed on blockchains (e.g. Ethereum L1 apps, L2s), this is N/A — list the deployed networks and note that finality is inherited from the underlying chain. Exception: L2s and L3s have their own finality time if their settlement adds delay beyond the underlying chain.",
+    description: "The time it takes for a transaction to be considered irreversible (in seconds).",
     metric: "Seconds or N/A",
     inputType: "text",
   },
@@ -111,24 +109,21 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
   {
     name: "Number of secrets",
     group: "UX",
-    description:
-      "How many new secrets must the user store to use the protocol. Only count secrets the user must independently back up — deterministically derived keys (e.g. a viewing key derived from a signed message) do not count as new secrets. The description should list all keys involved (spending key, viewing key, encryption key, etc.), how they are derived, and what cryptographic primitives are used (e.g. ECDH, BIP-32, EdDSA on Baby Jubjub). If everything derives from one wallet signature, the answer is 1.",
+    description: "How many new secrets must the user store to use the protocol.",
     metric: "Number of secrets",
     inputType: "number",
   },
   {
     name: "Deposit time",
     group: "UX",
-    description:
-      "Duration required before you can deposit into the protocol (in seconds). N/A for L1 protocols without a distinct deposit concept.",
+    description: "Duration required before you can deposit into the protocol (in seconds).",
     metric: "Seconds or N/A",
     inputType: "text",
   },
   {
     name: "Withdraw time",
     group: "UX",
-    description:
-      "Duration required before you can withdraw funds from the protocol (in seconds). N/A for L1 protocols without a distinct withdraw concept.",
+    description: "Duration required before you can withdraw funds from the protocol (in seconds).",
     metric: "Seconds or N/A",
     inputType: "text",
   },
@@ -138,7 +133,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Censorship resistance",
     group: "Decentralization & Security",
     description:
-      "Whether any entity can prevent valid transactions from being included in the chain. Considers mining/validator censorship, protocol-level restrictions, and network-level blocking. If the protocol uses relayers or broadcasters, note this in the description — but relayer dependence alone does not make the protocol censorship-susceptible if users can bypass relayers and interact with the underlying contracts directly.",
+      "Whether any entity can prevent valid transactions from being included in the chain. Considers mining/validator censorship, protocol-level restrictions, and network-level blocking.",
     metric: "Yes / No",
     inputType: "select",
     options: ["Yes", "No"],
@@ -155,7 +150,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Escape hatch",
     group: "Decentralization & Security",
     description:
-      "Whether users can withdraw shielded funds relying only on the underlying blockchain's consensus and cryptography. For standalone L1 blockchains, this may not apply.",
+      "Whether users can withdraw shielded funds relying only on the underlying blockchain's consensus and cryptography.",
     metric: "No / Can exit in a time period / Instantly / N/A",
     inputType: "select",
     options: ["No", "Can exit in a time period", "Instantly", "N/A"],
@@ -163,8 +158,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
   {
     name: "Upgradeability",
     group: "Decentralization & Security",
-    description:
-      "How upgrades to the system are performed. For L1 blockchains, this includes the mechanism by which protocol rules change (e.g. hard/soft forks via improvement proposal processes).",
+    description: "How upgrades to the system are performed.",
     metric: "Single admin / Multi-sig / DAO / Network upgrade (hard/soft fork) / Immutable",
     inputType: "select",
     options: ["Single admin", "Multi-sig", "DAO", "Network upgrade (hard/soft fork)", "Immutable"],
@@ -234,14 +228,13 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Type of compliance",
     group: "Compliance",
     description:
-      "What compliance mechanisms are available or enforced. POI/ASP: on-chain proof that funds are not associated with flagged addresses, using blocklists maintained with varying degrees of centralization. Selective disclosure: users can voluntarily reveal transaction details via viewing keys. KYC/KYB: identity verification required to participate. KYT: real-time transaction screening against risk databases. Programmatic policies: configurable rule-based restrictions (e.g. sanctions lists, allow/block lists). Other: compliance mechanism not covered above.",
-    metric: "POI/ASP / Selective disclosure / KYC/KYB / KYT / Programmatic policies / Other / None",
+      "What compliance mechanisms are available or enforced. Programmatic policies: programmable per-transaction rule sets, validated by an external API or oracle that returns a cryptographic attestation of compliance (Predicate-style). Data sources commonly include blockchain-analytics vendors (Chainalysis, TRM, Elliptic), ISACs, fraud-detection feeds, off-chain KYC platforms, and ZK-identity tools — these data inputs are subsumed under Programmatic policies, not separate categories. KYC/KYB: identity verification required to participate (passport / liveness / sanctions screening); ZK-identity is an emerging privacy-preserving variant of the same category. POI/ASP: inclusion/exclusion-based ZK proofs over a curated set — Proof of Innocence proves funds do NOT intersect a disallowed set; Association Set Provider proves funds DO belong to an allowed set. Same ZK primitive, opposite set semantics. Selective disclosure: users can voluntarily reveal transaction details via viewing keys. Other: compliance mechanism not covered above.",
+    metric: "POI/ASP / Selective disclosure / KYC/KYB / Programmatic policies / Other / None",
     inputType: "multi-select",
     options: [
       "Proof of innocence (POI) / ASP",
       "Selective disclosure",
       "KYC/KYB",
-      "KYT",
       "Programmatic policies",
       "Other",
       "None",
@@ -280,7 +273,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Cryptographic verifiability",
     group: "Verifiable",
     description:
-      "Whether transaction correctness is guaranteed by cryptographic proofs rather than social or majority-based mechanisms. For L1 blockchains, note that consensus (PoW/PoS) provides block ordering while cryptography verifies transaction validity — use 'Yes, with L1 consensus' to distinguish this mixed model. For protocols with upgradable contracts or permissioned components, note these additional trust assumptions.",
+      "Whether transaction correctness is guaranteed by cryptographic proofs rather than social or majority-based mechanisms.",
     metric: "Yes / Yes, with L1 consensus / No",
     inputType: "select",
     options: ["Yes", "Yes, with L1 consensus", "No"],
@@ -289,7 +282,7 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Open source",
     group: "Verifiable",
     description:
-      "The source code for the underlying protocol, any backend infrastructure, and any frontend applications is publicly available to inspect and has an open source software license. Check all critical repositories (contracts, circuits, SDKs) — different components may have different licenses. Source-available without a license is not open source.",
+      "The source code for the underlying protocol, any backend infrastructure, and any frontend applications is publicly available to inspect and has an OSI-approved open source license.",
     metric: "Yes / No",
     inputType: "select",
     options: ["Yes", "No"],
@@ -299,18 +292,11 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
   {
     name: "Private State Scalability",
     group: "State",
-    description: "How protocol-specific private data is stored over time",
+    description: "How protocol-specific private data grows over time.",
     metric:
-      "Infinity grow (nullifier/note trees grow forever) / Temporal grow (state pruned at epochs, stored offchain) / Stateless (state updated but does not grow) / L2 / Within contract / Off-chain DA with on-chain handles",
+      "Infinity grow (nullifier/note trees grow forever) / Temporal grow (state pruned at epochs, stored offchain) / Stateless (state updated but does not grow)",
     inputType: "select",
-    options: [
-      "Infinity grow",
-      "L2",
-      "Temporal grow",
-      "Stateless",
-      "Within contract",
-      "Off-chain DA with on-chain handles",
-    ],
+    options: ["Infinity grow", "Temporal grow", "Stateless"],
   },
   {
     name: "Client-side indexing",


### PR DESCRIPTION
**What this PR does:**
Restructure the research script into a multi-phase flow using Claude code skills:
1. Add the protocol to `scripts/research-config.ts`.
2. Run skill: `/research-sources <id>` in Claude Code to write `scripts/research-cache/<id>.json`.
3. Run script: `pnpm run research <id>` to write `src/data/evaluations/<id>.json`.
4. Run skill: `/review-evaluation <id>` to check against the rules in `scripts/research-prompts.ts`.
5. Prompt rules are automatically updated with review feedback

Above steps are composed into single skill:
`/evaluate-protocol <id>`

This reduces token usage significantly since the API is used only for citation feature.

- Introduce the new flow: `/research-sources` discovers URLs and writes `scripts/research-cache/{id}.json`, `scripts/research-protocol.ts` reads the cache, fetches each URL once, and calls the Anthropic API per property to get citations
- Switch the API call to the tool-use API. Claude now writes the note as a plain text block and records the structured value via a separate tool call (`record_evaluation`). Separating the two outputs gives the Citations API a clean text channel to attach source quotes to. The rule changes such as guidance on paraphrasing meant that citation feature stopped working, this changes makes citations more robust
- Enable prompt caching on the document block (document blocks needed by citation feature). Fetched pages are multiple KB each and previously re-sent per property. Caching the document means only the first per-URL call pays the full input cost, and the shared URLs across properties (5-10 unique URLs per 30-property run) hit the cache for the rest.
- Add many new rules in `research-prompts.ts`
- Rewrite rules in `research-prompts.ts`: reframe Cryptographic verifiability, fix Number of secrets minimum, add Selective-disclosure carveout to CROSS_CHECK_RULES, tighten WRITING/VALUE_FORMAT/PROPERTY rules
- Expand `research-config.ts`: add context field to ProtocolConfig and add Nullmask/Houdiniswap/Mirage etc entries with documentation and `sourceUrls`
- Upgrade model to claude-opus-4-7
- Reframe Type of compliance taxonomy in schema.ts (remove KYT; add Programmatic policies / KYC/KYB / POI/ASP). **This aligns our taxonomy with Predicate and INCO report**
- Add minimal README.md outlining the research flow
- Add .gitignore (ignore *.json and other local sources)

Skills were generated by claude and are added in next PR