### PR TITLE
Feat/update analysis

### DIFF
--- a/project-evaluations/src/data/evaluations/hinkal.json
+++ b/project-evaluations/src/data/evaluations/hinkal.json
@@ -119,8 +119,9 @@
     },
     {
       "name": "Type of compliance",
-      "value": "[\"KYT\",\"Selective disclosure\"]",
-      "notes": "Hinkal enforces Know-Your-Transaction (KYT) screening via Chainalysis compliance components integrated into the smart contracts. Screening applies at deposit and withdrawal, where public addresses are visible. Private transfers within the shielded pool are note-to-note and do not expose public addresses to the compliance layer. Users can also voluntarily share their viewing key with third parties for selective disclosure.",
+      "value": "[\"Programmatic policies\",\"Selective disclosure\"]",
+      "notes": "Hinkal enforces programmable per-transaction policies via Chainalysis compliance components integrated into the smart contracts; the chain-analytics signal is a data input to the policy layer (not a separate compliance category). Screening applies at deposit and withdrawal, where public addresses are visible. Private transfers within the shielded pool are note-to-note and do not expose public addresses to the compliance layer. Users can also voluntarily share their viewing key with third parties for selective disclosure.",
+      "needsResearchReview": true,
       "url": "https://hinkal-team.gitbook.io/hinkal/technical-description/compliance"
     },
     {

--- a/project-evaluations/src/data/evaluations/intmax.json
+++ b/project-evaluations/src/data/evaluations/intmax.json
@@ -115,8 +115,9 @@
     },
     {
       "name": "Type of compliance",
-      "value": "[\"KYT\",\"Proof of innocence (POI) / ASP\"]",
-      "notes": "Intmax applies Know Your Transaction (KYT) screening to incoming deposits and uses a Proof of Innocence (POI) model whereby users must demonstrate that their funds are not associated with sanctioned or illicit activity before being accepted into the network.",
+      "value": "[\"Programmatic policies\",\"Proof of innocence (POI) / ASP\"]",
+      "notes": "Intmax gates incoming deposits via Predicate AVS — a programmable per-deposit policy framework that returns a cryptographic attestation of compliance against rule sets sourcing from blockchain-analytics vendors. Predicate is the canonical example of programmatic policies. Users additionally demonstrate via a Proof of Innocence model that their funds are not associated with sanctioned or illicit activity before being accepted into the network.",
+      "needsResearchReview": true,
       "url": "https://docs.network.intmax.io/user-guides/privacy-mining/#aml-rules"
     },
     {
@@ -139,8 +140,9 @@
     },
     {
       "name": "Cryptographic verifiability",
-      "value": "No",
-      "notes": "State transitions within Intmax are cryptographically verified using Plonky2 ZK proofs with FRI commitments and BN254 curve operations. However, the overall system has additional trust assumptions beyond cryptography: contracts are upgradable by a 2/4 multisig with no time delay or exit window, deposits are gated by Predicate AVS (a permissioned AML screening layer), and balance data is entirely self-custodied with no on-chain recovery mechanism. The system settles through Scroll (L2) to Ethereum (L1), inheriting their respective trust models. While the proof system itself is cryptographically sound, the protocol's correctness guarantees are not purely cryptographic.",
+      "value": "Yes",
+      "notes": "State transitions within Intmax are cryptographically verified using Plonky2 ZK proofs with FRI commitments and BN254 curve operations — an external observer can re-check the proofs against the published verifier. Additional trust concerns (contracts upgradable by a 2/4 multisig, Predicate AVS deposit gating, self-custodied balance data) are captured separately by Upgradeability and Censorship resistance rather than this property. The system settles through Scroll (L2) to Ethereum (L1), inheriting their consensus models for ordering.",
+      "needsResearchReview": true,
       "url": "https://docs.network.intmax.io/developers-hub/security-and-privacy/architecture-principles"
     },
     {
@@ -151,8 +153,8 @@
     },
     {
       "name": "Private State Scalability",
-      "value": "L2",
-      "notes": "Users maintain their own state locally on their devices. Only salted transaction hashes and block commitments are published to the settlement layer. There is no global shared state that grows with usage — state growth is distributed across individual users.",
+      "value": "Stateless",
+      "notes": "Users maintain their own state locally on their devices. A significant part of state growth is distributed across individual users. Aggregators post the Merkle root, aggregated signature, and public key list to the rollup contract. The contract verifies aggregate proofs",
       "url": "https://docs.network.intmax.io/developers-hub/core-concepts/roles"
     },
     {

--- a/project-evaluations/src/data/evaluations/privacy-pools.json
+++ b/project-evaluations/src/data/evaluations/privacy-pools.json
@@ -176,7 +176,7 @@
     {
       "name": "Access to DeFi",
       "value": "No access to DeFi",
-      "notes": "Privacy Pools implemented a yield earning module for some of its token pools. This means that some tokens can earn yield privately while being idle on the anonymity pool. There is no mention about the yield module in the documentation but there is an announcement on social media and the UI shows some pools APR percentage.",
+      "notes": "Privacy Pools implemented a yield earning module for some of its token pools. This means that some tokens can earn yield privately while being idle on the anonymity pool. There is no mention of the yield module in the official docs but there is an announcement on social media and the UI shows some pools' APR percentage.",
       "url": "https://x.com/0xprivacypools/status/2010441283211530254"
     },
     {

--- a/project-evaluations/src/data/evaluations/redact.json
+++ b/project-evaluations/src/data/evaluations/redact.json
@@ -144,7 +144,8 @@
     {
       "name": "Cryptographic verifiability",
       "value": "No",
-      "notes": "The system relies on a permissioned threshold network for decryption and an off-chain DA layer for ciphertext storage, introducing crypto-economic trust assumptions beyond pure cryptographic guarantees. The CoFHE architecture claims to use zero-knowledge proofs of knowledge (ZKPoK) alongside TFHE, but the specific verification mechanism is not detailed in current documentation. TODO: verify whether ZKPoK verification is implemented ",
+      "notes": "Correctness rests on a permissioned threshold-decryption network (an economic / multi-party trust mechanism), so the value is No per the rule that excludes economic mechanisms from cryptographic verifiability. The CoFHE architecture claims to use zero-knowledge proofs of knowledge (ZKPoK) alongside TFHE, but even if ZKPoK is implemented, decryption itself depends on threshold-network honesty rather than pure math. TODO: verify whether ZKPoK verification is implemented (this would not flip the value but would tighten the description).",
+      "needsResearchReview": true,
       "url": "https://docs.redact.money/architecture/cofhe-overview#security-and-privacy-measures"
     },
     {
@@ -155,9 +156,10 @@
     },
     {
       "name": "Private State Scalability",
-      "value": "Off-chain DA with on-chain handles",
-      "notes": "Redact uses an account-based model where each user's encrypted balance handle is stored as a mapping within the smart contract storage. On-chain state grows proportionally to the number of accounts. Full ciphertexts grow on the off-chain DA layer proportionally to the number of operations.",
-      "url": "https://docs.redact.money/architecture/fherc20-token-standard#encrypted-balances"
+      "value": "Infinity grow",
+      "notes": "Redact uses an account-based model where each user's encrypted balance handle is stored as a mapping within the smart contract storage. On-chain state grows proportionally to the number of accounts. Full ciphertexts grow on the off-chain DA layer proportionally to the number of operations — every transfer emits a new ciphertext that must be retained for balance reconstruction.",
+      "url": "https://docs.redact.money/architecture/fherc20-token-standard#encrypted-balances",
+      "needsResearchReview": true
     },
     {
       "name": "Client-side indexing",

--- a/project-evaluations/src/data/evaluations/tongo.json
+++ b/project-evaluations/src/data/evaluations/tongo.json
@@ -155,7 +155,7 @@
     },
     {
       "name": "Private State Scalability",
-      "value": "Within contract",
+      "value": "Stateless",
       "notes": "Tongo uses an account-based model where each user's encrypted balance is stored as a mapping within the smart contract storage. New users add entries to the contract's account mapping, and the state grows proportionally to the number of accounts rather than to the number of transactions.",
       "url": "https://docs.tongo.cash/protocol/storage.html"
     },

--- a/project-evaluations/src/data/evaluations/zcash.json
+++ b/project-evaluations/src/data/evaluations/zcash.json
@@ -433,8 +433,9 @@
     },
     {
       "name": "Cryptographic verifiability",
-      "value": "Yes",
-      "notes": "Yes, ZCash has cryptographic verifiability. The acronym zk-SNARK stands for Zero-Knowledge Succinct Non-Interactive Argument of Knowledge and refers to a proof construction where one can prove possession of certain information without revealing that information and without any interaction between the prover and verifier. Shielded transactions in Zcash can be fully encrypted on the blockchain, yet still be verified as valid under the network's consensus rules by using zk-SNARK proofs. These succinct zero-knowledge proofs can be verified within a few milliseconds, with a proof length of only a few hundred bytes, and in non-interactive constructions, the proof consists of a single message sent from prover to verifier.",
+      "value": "Yes, with L1 consensus",
+      "notes": "Zcash is an L1 blockchain whose individual transaction correctness is enforced by zk-SNARK verification (Halo2 / Orchard, Groth16 for legacy Sapling), while block ordering and inclusion are decided by majority-based PoW consensus. Shielded transactions are fully encrypted on-chain yet still verifiable as valid under the network's consensus rules. Per the rule, L1 protocols with cryptographic transaction correctness plus consensus-based ordering take \"Yes, with L1 consensus\".",
+      "needsResearchReview": true,
       "citations": [
         {
           "cited_text": "The acronym zk-SNARK stands for Zero-Knowledge Succinct Non-Interactive Argument of Knowledge and refers to a proof construction where one can prove possession of certain information, e.g., a secret key, without revealing that information, and without any interaction between the prover and verifier.\n\n",


### PR DESCRIPTION
- Type of compliance taxonomy reframed — removed KYT (conflated a data source with a compliance mode). New enum adds Programmatic policies and aligns with the Predicate / INCO report definitions.                                                                                                                
- Cryptographic verifiability reframed — property now only asks whether transaction correctness is enforced by cryptographic proofs. Admin-upgradability and off-chain DA concerns move to Upgradeability / Censorship resistance. New "Yes, with L1 consensus" value for L1s with consensus                                                                                                                                                                                                                                                                             
- Private State Scalability enum collapsed to Infinity grow / Temporal grow / Stateless.                                                                                                                                                                                                                 
- WRITING_RULES tightening — minor grammar fixes. 