### PR TITLE
chore(benchmarks): add redact shield tests

### DIFF
--- a/subgraph/tests/railgun/railgun-smart-wallet-shield.test.ts
+++ b/subgraph/tests/railgun/railgun-smart-wallet-shield.test.ts
@@ -1,7 +1,7 @@
 import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
 
-import { handleShield } from "../src/railgun/railgun-smart-wallet";
+import { handleShield } from "../../src/railgun/railgun-smart-wallet";
 
 import { createShieldEvent, createCommitmentTuple, createShieldCiphertextTuple } from "./railgun-smart-wallet-utils";
 

--- a/subgraph/tests/railgun/railgun-smart-wallet-transact.test.ts
+++ b/subgraph/tests/railgun/railgun-smart-wallet-transact.test.ts
@@ -1,7 +1,7 @@
 import { BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
 
-import { handleTransact } from "../src/railgun/railgun-smart-wallet";
+import { handleTransact } from "../../src/railgun/railgun-smart-wallet";
 
 import { createTransactEvent, createTransactCiphertextTuple } from "./railgun-smart-wallet-utils";
 

--- a/subgraph/tests/railgun/railgun-smart-wallet-unshield.test.ts
+++ b/subgraph/tests/railgun/railgun-smart-wallet-unshield.test.ts
@@ -1,7 +1,7 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
 import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
 
-import { handleUnshield } from "../src/railgun/railgun-smart-wallet";
+import { handleUnshield } from "../../src/railgun/railgun-smart-wallet";
 
 import { createUnshieldEvent } from "./railgun-smart-wallet-utils";
 

--- a/subgraph/tests/railgun/railgun-smart-wallet-utils.ts
+++ b/subgraph/tests/railgun/railgun-smart-wallet-utils.ts
@@ -1,7 +1,7 @@
 import { ethereum, BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
 import { newMockEvent } from "matchstick-as";
 
-import { Shield, Transact, Unshield } from "../generated/RailgunSmartWallet/RailgunSmartWallet";
+import { Shield, Transact, Unshield } from "../../generated/RailgunSmartWallet/RailgunSmartWallet";
 
 export function createShieldEvent(
   treeNumber: BigInt,

--- a/subgraph/tests/redact/redact-confidential-eth-shield.test.ts
+++ b/subgraph/tests/redact/redact-confidential-eth-shield.test.ts
@@ -1,0 +1,54 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+
+import { handleShieldedNative } from "../../src/redact/confidential-eth";
+
+import { createShieldedNativeEvent } from "./redact-confidential-eth-utils";
+
+describe("ShieldedNative event tests", () => {
+  beforeAll(() => {
+    const event = createShieldedNativeEvent(
+      Address.fromString("0x0000000000000000000000000000000000000001"),
+      Address.fromString("0x0000000000000000000000000000000000000002"),
+      BigInt.fromI32(100),
+    );
+
+    handleShieldedNative(event);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  test("RedactShieldedNative created", () => {
+    assert.entityCount("RedactShieldedNative", 1);
+  });
+
+  test("RedactShieldedNative values stored correctly", () => {
+    const id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1";
+
+    assert.fieldEquals("RedactShieldedNative", id, "from", "0x0000000000000000000000000000000000000001");
+    assert.fieldEquals("RedactShieldedNative", id, "to", "0x0000000000000000000000000000000000000002");
+    assert.fieldEquals("RedactShieldedNative", id, "value", "100");
+  });
+
+  test("Protocol stats updated", () => {
+    assert.fieldEquals("RedactProtocolStats", "redact-protocol-stats", "totalTxCount", "1");
+    assert.fieldEquals("RedactProtocolStats", "redact-protocol-stats", "totalGasUsed", "1");
+  });
+
+  test("Operation stats updated (shield-native)", () => {
+    assert.fieldEquals("RedactOperationStats", "redact-protocol-stats-shield-native", "totalCount", "1");
+    assert.fieldEquals("RedactOperationStats", "redact-protocol-stats-shield-native", "totalGasUsed", "1");
+  });
+
+  test("Shielded token stats updated", () => {
+    const id = "0x0000000000000000000000000000000000000000";
+
+    assert.entityCount("RedactShieldedStats", 1);
+    assert.fieldEquals("RedactShieldedStats", id, "tokenAddress", "0x0000000000000000000000000000000000000000");
+    assert.fieldEquals("RedactShieldedStats", id, "totalValue", "100");
+    assert.fieldEquals("RedactShieldedStats", id, "totalCount", "1");
+    assert.fieldEquals("RedactShieldedStats", id, "totalGasUsed", "1");
+  });
+});

--- a/subgraph/tests/redact/redact-confidential-eth-utils.ts
+++ b/subgraph/tests/redact/redact-confidential-eth-utils.ts
@@ -1,0 +1,15 @@
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+
+import { ShieldedNative } from "../../generated/ConfidentialETH/ConfidentialETH";
+
+export function createShieldedNativeEvent(from: Address, to: Address, value: BigInt): ShieldedNative {
+  const event = changetype<ShieldedNative>(newMockEvent());
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("from", ethereum.Value.fromAddress(from)));
+  event.parameters.push(new ethereum.EventParam("to", ethereum.Value.fromAddress(to)));
+  event.parameters.push(new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value)));
+
+  return event;
+}


### PR DESCRIPTION
1. Move railgun tests to a specific protocol folder
2. Add tests for redact shield


Wait for https://github.com/privacy-ethereum/private-transfers-benchmarks/pull/173 to be merged first