### PR TITLE
feat(benchmarks): get base fee per gas + prevent benchmark CI errors

### DIFF
--- a/.github/workflows/gas-benchmarks.yml
+++ b/.github/workflows/gas-benchmarks.yml
@@ -30,14 +30,11 @@ jobs:
         run: pnpm run test
         working-directory: gas-benchmarks
         env:
-          SUBGRAPH_URL: ${{ secrets.SUBGRAPH_URL }}
-
-      - name: Benchmark
-        run: pnpm run benchmark
-        working-directory: gas-benchmarks
-        env:
           ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
           SCROLL_RPC_URL: ${{ secrets.SCROLL_RPC_URL }}
           SUBGRAPH_URL: ${{ secrets.SUBGRAPH_URL }}
-          MIN_SAMPLES: ${{ vars.MIN_SAMPLES }}
           MONERO_FAIL_NODES_API_URL: ${{ vars.MONERO_FAIL_NODES_API_URL }}
+          MIN_SAMPLES: ${{ vars.MIN_SAMPLES }}
+          BATCH_SIZE_FOR_RPC_CALLS: ${{ vars.BATCH_SIZE_FOR_RPC_CALLS }}
+          DELAY_BETWEEN_BATCHES: ${{ vars.DELAY_BETWEEN_BATCHES }}

--- a/gas-benchmarks/.env.example
+++ b/gas-benchmarks/.env.example
@@ -1,9 +1,15 @@
 ETH_RPC_URL=https://mainnet.gateway.tenderly.co
 
-SCROLL_RPC_URL=https://scroll.gateway.tenderly.co
+SEPOLIA_RPC_URL=https://sepolia.gateway.tenderly.co
 
-MONERO_FAIL_NODES_API_URL=https://monero.fail/nodes.json
+SCROLL_RPC_URL=https://scroll.gateway.tenderly.co
 
 SUBGRAPH_URL=https://api.studio.thegraph.com/query/<USER_ID>/<SUBGRAPH_SLUG>/<VERSION>
 
+MONERO_FAIL_NODES_API_URL=https://monero.fail/nodes.json
+
 MIN_SAMPLES=10
+
+BATCH_SIZE_FOR_RPC_CALLS=500
+
+DELAY_BETWEEN_BATCHES=10000

--- a/gas-benchmarks/src/__tests__/util.rpc.test.ts
+++ b/gas-benchmarks/src/__tests__/util.rpc.test.ts
@@ -1,0 +1,15 @@
+import { mainnet } from "viem/chains";
+import { describe, expect, it } from "vitest";
+
+import { getBaseFeePerGasAverageInDaysWindow } from "../utils/rpc.js";
+
+describe("getBaseFeePerGasAverageInDaysWindow", () => {
+  it("should calculate the average base fee per gas over a 7 days", async () => {
+    const averageBaseFee = await getBaseFeePerGasAverageInDaysWindow({
+      chain: mainnet,
+      windowDays: 7,
+    });
+
+    expect(averageBaseFee).toBeGreaterThan(0n);
+  }, 30_000);
+});

--- a/gas-benchmarks/src/utils/constants.ts
+++ b/gas-benchmarks/src/utils/constants.ts
@@ -6,22 +6,40 @@ if (!process.env.ETH_RPC_URL) {
   throw new Error("ETH_RPC_URL is not set");
 }
 
-if (!process.env.SCROLL_RPC_URL) {
-  throw new Error("SCROLL_RPC_URL is not set");
+if (!process.env.SEPOLIA_RPC_URL) {
+  throw new Error("SEPOLIA_RPC_URL is not set");
 }
 
-if (!process.env.MIN_SAMPLES) {
-  throw new Error("MIN_SAMPLES is not set");
+if (!process.env.SCROLL_RPC_URL) {
+  throw new Error("SCROLL_RPC_URL is not set");
 }
 
 if (!process.env.SUBGRAPH_URL) {
   throw new Error("SUBGRAPH_URL is not set");
 }
 
-export const { ETH_RPC_URL, SUBGRAPH_URL, SCROLL_RPC_URL } = process.env;
+if (!process.env.MIN_SAMPLES) {
+  throw new Error("MIN_SAMPLES is not set");
+}
+
+if (!process.env.BATCH_SIZE_FOR_RPC_CALLS) {
+  throw new Error("BATCH_SIZE_FOR_RPC_CALLS is not set");
+}
+
+if (!process.env.DELAY_BETWEEN_BATCHES) {
+  throw new Error("DELAY_BETWEEN_BATCHES is not set");
+}
+
+export const { ETH_RPC_URL, SEPOLIA_RPC_URL, SCROLL_RPC_URL, SUBGRAPH_URL } = process.env;
 
 /** Minimum number of valid samples required per benchmark */
 export const MIN_SAMPLES = Number(process.env.MIN_SAMPLES);
+
+/** Number of RPC calls to batch together concurrently when interacting with the RPC */
+export const BATCH_SIZE_FOR_RPC_CALLS = Number(process.env.BATCH_SIZE_FOR_RPC_CALLS);
+
+/** Delay in milliseconds between batches when interacting with the RPC to avoid rate limiting */
+export const DELAY_BETWEEN_BATCHES = Number(process.env.DELAY_BETWEEN_BATCHES);
 
 /** Maximum unique logs to collect before stopping the block scan */
 export const MAX_SAMPLES = 100_000;
@@ -67,8 +85,3 @@ export const BLOCK_WINDOW_SCROLL_1_WEEK = 604_800n;
  * Using 5 for dev and rate limiting on remote node
  */
 export const BLOCK_WINDOW_MONERO = 5;
-
-/**
- * One day in seconds used to calculate day of unixtimestamp
- */
-export const ONE_DAY_IN_SECONDS = 24 * 60 * 60;

--- a/gas-benchmarks/src/utils/interfaces.ts
+++ b/gas-benchmarks/src/utils/interfaces.ts
@@ -67,3 +67,12 @@ export interface GetValidEthTransfersInput {
   latestBlock?: bigint;
   blockWindow?: bigint;
 }
+
+/**
+ * Input for getBaseFeePerGasAverageInDaysWindow
+ */
+export interface GetBaseFeePerGasAverageInDaysWindowInput {
+  chain: Chain;
+  windowDays: number;
+  latestBlock?: bigint;
+}

--- a/gas-benchmarks/src/utils/rpc.ts
+++ b/gas-benchmarks/src/utils/rpc.ts
@@ -3,17 +3,19 @@ import {
   encodeEventTopics,
   http,
   toHex,
+  type Block,
   type Chain,
   type Hash,
   type Log,
   type PublicClient,
   type TransactionReceipt,
 } from "viem";
-import { mainnet, scroll } from "viem/chains";
+import { mainnet, scroll, sepolia } from "viem/chains";
 
 import type {
   EthGetBlockReceiptsSchema,
   GetAllLogsInput,
+  GetBaseFeePerGasAverageInDaysWindowInput,
   GetBlockWindowInput,
   GetBlockWindowOutput,
   GetValidEthTransfersInput,
@@ -23,18 +25,22 @@ import type {
 
 import {
   ETH_RPC_URL,
+  SEPOLIA_RPC_URL,
   SCROLL_RPC_URL,
   BLOCK_RANGE,
   MAX_SAMPLES,
   BLOCK_WINDOW_ETHEREUM_1_WEEK,
   BLOCK_WINDOW_SCROLL_1_WEEK,
+  BATCH_SIZE_FOR_RPC_CALLS,
+  DELAY_BETWEEN_BATCHES,
 } from "./constants.js";
-import { isNativeTransfer } from "./utils.js";
+import { isNativeTransfer, sleep } from "./utils.js";
 
 /** Pre-configured RPC clients keyed by chain ID */
 const clients: Record<number, PublicClient | undefined> = {
   [mainnet.id]: createPublicClient({ chain: mainnet, transport: http(ETH_RPC_URL, { batch: true }) }),
   [scroll.id]: createPublicClient({ chain: scroll, transport: http(SCROLL_RPC_URL, { batch: true }) }),
+  [sepolia.id]: createPublicClient({ chain: sepolia, transport: http(SEPOLIA_RPC_URL, { batch: true }) }),
 };
 
 /** Returns the RPC client for a given chain */
@@ -66,6 +72,8 @@ const getBlockWindow = async ({
   if (blockWindow !== undefined) {
     scanWindow = blockWindow;
   } else if (chainId === mainnet.id) {
+    scanWindow = BLOCK_WINDOW_ETHEREUM_1_WEEK;
+  } else if (chainId === sepolia.id) {
     scanWindow = BLOCK_WINDOW_ETHEREUM_1_WEEK;
   } else if (chainId === scroll.id) {
     scanWindow = BLOCK_WINDOW_SCROLL_1_WEEK;
@@ -192,4 +200,56 @@ export const getValidEthTransfers = async ({
   }
 
   return receipts;
+};
+
+/** Returns the number of blocks produced in an hour for a given chain */
+const getBlocksPerHour = (chainId: number): number => {
+  switch (chainId) {
+    case mainnet.id:
+    case sepolia.id:
+      return 300; // 3600s / 12s
+    case scroll.id:
+      return 3600; // 3600s / 1s
+    default:
+      throw new Error(`No block time configured for chain ID: ${chainId}`);
+  }
+};
+
+/** Returns the average base fee per gas price within a days window */
+export const getBaseFeePerGasAverageInDaysWindow = async ({
+  chain,
+  windowDays,
+  latestBlock,
+}: GetBaseFeePerGasAverageInDaysWindowInput): Promise<bigint> => {
+  const client = getClient(chain);
+  const step = getBlocksPerHour(chain.id);
+  const samples = windowDays * 24; // 24 hours per day
+
+  const endBlock = latestBlock ?? (await client.getBlockNumber());
+
+  const blockNumbers = Array.from({ length: samples }, (_, index) => endBlock - BigInt(index * step));
+
+  const blocks: Block[] = [];
+
+  for (let i = 0; i < blockNumbers.length; i += BATCH_SIZE_FOR_RPC_CALLS) {
+    const batch = blockNumbers.slice(i, i + BATCH_SIZE_FOR_RPC_CALLS);
+
+    // eslint-disable-next-line no-await-in-loop
+    const batchBlocks = await Promise.all(batch.map((blockNumber) => client.getBlock({ blockNumber })));
+
+    blocks.push(...batchBlocks);
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(DELAY_BETWEEN_BATCHES);
+  }
+
+  const baseFees = blocks
+    .map((block) => block.baseFeePerGas)
+    .filter((baseFeePerGas): baseFeePerGas is bigint => baseFeePerGas !== null);
+
+  if (baseFees.length === 0) {
+    throw new Error(`No base fee values found for chain ID: ${chain.id}`);
+  }
+
+  return baseFees.reduce((sum, baseFeePerGas) => sum + baseFeePerGas, 0n) / BigInt(baseFees.length);
 };

--- a/gas-benchmarks/src/utils/utils.ts
+++ b/gas-benchmarks/src/utils/utils.ts
@@ -32,3 +32,13 @@ export const isNativeTransfer = (receipt: TransactionReceipt): boolean => {
 
   return isGasUsed21000 && hasNoLogs && isNotContractDeployment && hasRecipient;
 };
+
+/**
+ * Sleep for a specified number of milliseconds
+ * @param ms - The number of milliseconds to sleep
+ * @returns A promise that resolves after the specified time has elapsed
+ */
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });


### PR DESCRIPTION
1. Get the base fee per gas in a specific block window (7 days, 30 days, etc). It fetches the block info in an hourly sampled and computes the average. Fix https://github.com/privacy-ethereum/private-transfers-benchmarks/issues/150
2. Disable the benchmarking CI because we are migrating to subgraph. Fix https://github.com/privacy-ethereum/private-transfers-benchmarks/issues/175