### PR TITLE
feat(evaluations): deploy dashboard in github pages

### DIFF
--- a/.github/workflows/deploy-dashboard-page.yml
+++ b/.github/workflows/deploy-dashboard-page.yml
@@ -1,0 +1,55 @@
+name: deploy-dashboard-page
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy-dashboard-page:
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+
+    permissions:
+      actions: write
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+        working-directory: project-evaluations
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: project-evaluations/dist
+
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/project-evaluations/vite.config.ts
+++ b/project-evaluations/vite.config.ts
@@ -6,6 +6,7 @@ const now = new Date();
 const buildVersion = `v${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, "0")}`;
 
 export default defineConfig({
+  base: "/",
   plugins: [react(), tailwindcss()],
   define: {
     __APP_VERSION__: JSON.stringify(buildVersion),


### PR DESCRIPTION
# What this PR does

Deploy the private-transfers-dashboard to a Github page so it is easier to link for the EF devops team

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have supplied a PR description that explains what the PR does.
- [X] I have linked a github issue to the PR if one exists.
- [X] I ran and verified that all tests pass locally.
