### PR TITLE
feat(subgraph): add worm

### DIFF
--- a/subgraph/abis/worm/WETH.json
+++ b/subgraph/abis/worm/WETH.json
@@ -1,0 +1,153 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "guy", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "src", "type": "address" },
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "wad", "type": "uint256" }],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "dst", "type": "address" },
+      { "name": "wad", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "address" },
+      { "name": "", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "guy", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "dst", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "src", "type": "address" },
+      { "indexed": false, "name": "wad", "type": "uint256" }
+    ],
+    "name": "Withdrawal",
+    "type": "event"
+  }
+]

--- a/subgraph/configuration/subgraph.mainnet.yaml
+++ b/subgraph/configuration/subgraph.mainnet.yaml
@@ -138,6 +138,30 @@ dataSources:
           handler: handlePoolRemoved
       file: ../src/privacy-pools/privacy-pools.ts
 
+  - kind: ethereum
+    name: WETH
+    network: mainnet
+    source:
+      address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+      abi: WETH
+      startBlock: 24436025
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - WormProtocolStats
+        - WormOperationStats
+        - WormWithdraw
+      abis:
+        - name: WETH
+          file: ../abis/worm/WETH.json
+      eventHandlers:
+        - event: Withdrawal(indexed address,uint256)
+          handler: handleWithdrawal
+          receipt: true
+      file: ../src/worm/weth.ts
+
 templates:
   - kind: ethereum
     name: TornadoInstance

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -463,3 +463,28 @@ type TornadoCashWithdrawal @entity(immutable: true) {
   gasUsed: BigInt!
   gasPrice: BigInt!
 }
+
+type WormProtocolStats @entity(immutable: false) {
+  id: ID!
+  totalTxCount: BigInt!
+  totalGasUsed: BigInt!
+
+  withdraw: WormOperationStats!
+}
+
+type WormOperationStats @entity(immutable: false) {
+  id: ID!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+}
+
+type WormWithdraw @entity(immutable: true) {
+  id: ID!
+  value: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}

--- a/subgraph/schemas/worm.graphql
+++ b/subgraph/schemas/worm.graphql
@@ -1,0 +1,24 @@
+type WormProtocolStats @entity(immutable: false) {
+  id: ID!
+  totalTxCount: BigInt!
+  totalGasUsed: BigInt!
+
+  withdraw: WormOperationStats!
+}
+
+type WormOperationStats @entity(immutable: false) {
+  id: ID!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+}
+
+type WormWithdraw @entity(immutable: true) {
+  id: ID!
+  value: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -1,0 +1,19 @@
+import { crypto as graphCrypto, ethereum, Bytes } from "@graphprotocol/graph-ts";
+
+export function logsMatchEvents(logs: ethereum.Log[], events: string[]): boolean {
+  if (logs.length !== events.length) {
+    return false;
+  }
+
+  for (let i = 0; i < logs.length; i += 1) {
+    const event = Bytes.fromUTF8(events[i]);
+    const signature = graphCrypto.keccak256(event);
+    const topic = logs[i].topics[0];
+
+    if (!signature.equals(topic)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/subgraph/src/worm/README.md
+++ b/subgraph/src/worm/README.md
@@ -1,0 +1,33 @@
+# WORM
+
+## Contracts
+
+- **BETH:** is a ERC20 token contract with custom functions to mint and spend Burned ETH (BETH) tokens. In order to mint BETH, users need to show a ZK proof that a burn address has received a certain amount of ETH.
+  - Address: 0x5624344235607940d4d4EE76Bf8817d403EB9Cf8
+  - Contract: [BETH](https://github.com/worm-privacy/worm/blob/main/src/BETH.sol)
+- **WETH:** is the canonical WETH contract used in Ethereum mainnet. WORM uses this contract to swap BETH to WETH and then withdraw WETH to ETH when users want to withdraw their funds from WORM.
+  - Address: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+  - Contract: [WETH](https://github.com/gnosis/canonical-weth/blob/master/contracts/WETH9.sol)
+
+## Deposit (public to burn)
+
+1. Sender [transfers funds](https://etherscan.io/tx/0x85e79d05c72593bee8d00a430c6566c18a90ec946e9cc9296efb98add74f3f57) to a burn address. Looks like a normal native ETH or ERC20 transfer.
+
+## Withdraw (mint BETH, swap BETH to ETH, send ETH to public)
+
+1. Relayer sends a ["Mint Coin"](https://etherscan.io/tx/0xd061205b90ce8bcb8a8b5c8d279e0f3bf03ae9a75c9954b2297fb8933e1ecc1d) to the BETH contract to executed the withdrawal steps:
+   1. Verify the ZK proof
+   2. Mint BETH tokens for the prover
+   3. Transfer BETH tokens to the prover
+   4. Mint BETH tokens for the broadcaster
+   5. Transfer BETH tokens to the broadcaster
+   6. Mint BETH tokens for the recipient
+   7. Swap BETH to WETH in a DEX contract
+   8. Withdraw WETH to ETH
+   9. Send ETH to the recipient
+   10. Mint BETH tokens for the rewards pool
+   11. Transfer BETH tokens to the rewards pool
+
+   As you can see, the function performs 4 transactions: pay the prover, pay the broadcaster, pay the recipient and pay the rewards pool. Just after the contract mints BETH to the recipient, the contract swaps BETH to WETH, withdraws WETH to ETH and finally sends ETH to the recipient. All these steps are specified in the `receiverPostMintHook` bytes parameter of the `mintCoin` function. In order to retrieve all possible WORM withdraw transactions, we will scan the WETH contract for all `Withdraw` events that the caller is the BETH contract. This way we can be sure we are only retrieving WORM withdraw-ETH transactions and we are covering all different ways a user can withdraw funds from WORM (e.g. using a EOA, using a smart account, etc). We will save the transaction hash of each handled event in order to prevent duplicates where `broadcasterFeePostMintHook` and ` proverFeePostMintHook` also withdraw ETH through the WETH contract.
+
+   You can check the function code [here](https://github.com/worm-privacy/worm/blob/a16ea70908d13ebe0d737b4ac89c4bdafad20bf1/src/BETH.sol#L165)

--- a/subgraph/src/worm/beth.ts
+++ b/subgraph/src/worm/beth.ts
@@ -1,0 +1,106 @@
+import { BigInt, Bytes } from "@graphprotocol/graph-ts";
+
+import { Transfer as TransferEvent } from "../../generated/BETH/BETH";
+import { WormOperationStats, WormProtocolStats, WormWithdraw } from "../../generated/schema";
+import { logsMatchEvents } from "../utils";
+
+export const WITHDRAW_EVENTS = [
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Approval(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Approval(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Swap(address,address,int256,int256,uint160,uint128,int24,uint24,uint24)",
+  "Approval(address,address,uint256)",
+  "Withdraw(address,uint256)",
+  "Approval(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "Approval(address,address,uint256)",
+  "Transfer(address,address,uint256)",
+  "RewardDeposited(address,uint256,uint256)",
+  "Approval(address,address,uint256)",
+];
+
+export const INDEX_FOR_WETH_WITHDRAW_EVENT = 12;
+export const INDEX_FOR_TRANSFER_TO_FINAL_RECIPIENT_EVENT = 14;
+
+function createOrLoadProtocolStats(): WormProtocolStats {
+  const id = "worm-protocol-stats";
+  let stats = WormProtocolStats.load(id);
+
+  if (stats == null) {
+    stats = new WormProtocolStats(id);
+    stats.totalTxCount = BigInt.fromI32(0);
+    stats.totalGasUsed = BigInt.fromI32(0);
+
+    const withdraw = new WormOperationStats(`${id}-withdraw`);
+    stats.withdraw = withdraw.id;
+
+    withdraw.totalCount = BigInt.fromI32(0);
+    withdraw.totalGasUsed = BigInt.fromI32(0);
+
+    withdraw.save();
+    stats.save();
+  }
+
+  return stats;
+}
+
+export function handleTransfer(event: TransferEvent): void {
+  const id = `${event.transaction.hash.toHex()}`;
+
+  let withdraw = WormWithdraw.load(id);
+
+  if (withdraw != null) {
+    return; // tx already processed
+  }
+
+  if (event.receipt === null) {
+    return; // we need the receipt to get the logs/events of the tx
+  }
+
+  const isWithdraw = logsMatchEvents(event.receipt!.logs, WITHDRAW_EVENTS);
+
+  if (!isWithdraw) {
+    return; // not a withdraw tx, ignore
+  }
+
+  // the unwrapped amount of WETH is the amount being sent
+  const amountBytes = event.receipt!.logs[INDEX_FOR_WETH_WITHDRAW_EVENT].topics[2];
+  // 0 tokens ERC20 transfer event indicating receiver. The transfer is a native ETH internal transfer
+  const receiverTopic = event.receipt!.logs[INDEX_FOR_TRANSFER_TO_FINAL_RECIPIENT_EVENT].topics[2];
+  const receiverHex = receiverTopic.toHexString();
+  const receiver = Bytes.fromHexString(`0x${receiverHex.slice(26)}`);
+
+  withdraw = new WormWithdraw(id);
+  withdraw.value = BigInt.fromUnsignedBytes(Bytes.fromUint8Array(amountBytes.reverse()));
+  withdraw.to = receiver;
+
+  withdraw.blockNumber = event.block.number;
+  withdraw.timestamp = event.block.timestamp;
+  withdraw.txHash = event.transaction.hash;
+  withdraw.gasUsed = event.receipt!.gasUsed;
+  withdraw.gasPrice = event.transaction.gasPrice;
+
+  withdraw.save();
+
+  const stats = createOrLoadProtocolStats();
+  stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
+  stats.totalGasUsed = stats.totalGasUsed.plus(event.receipt!.gasUsed);
+
+  const operationStats = WormOperationStats.load(stats.withdraw);
+
+  if (operationStats !== null) {
+    operationStats.totalCount = operationStats.totalCount.plus(BigInt.fromI32(1));
+    operationStats.totalGasUsed = operationStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    operationStats.save();
+  }
+
+  stats.save();
+}

--- a/subgraph/src/worm/weth.ts
+++ b/subgraph/src/worm/weth.ts
@@ -1,0 +1,75 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+
+import { WormOperationStats, WormProtocolStats, WormWithdraw } from "../../generated/schema";
+import { Withdrawal as WithdrawalEvent } from "../../generated/WETH/WETH";
+
+export const BETH_CONTRACT_ADDRESS = Address.fromString("0x5624344235607940d4d4ee76bf8817d403eb9cf8");
+
+function createOrLoadProtocolStats(): WormProtocolStats {
+  const id = "worm-protocol-stats";
+  let stats = WormProtocolStats.load(id);
+
+  if (stats == null) {
+    stats = new WormProtocolStats(id);
+    stats.totalTxCount = BigInt.fromI32(0);
+    stats.totalGasUsed = BigInt.fromI32(0);
+
+    const withdraw = new WormOperationStats(`${id}-withdraw`);
+    stats.withdraw = withdraw.id;
+
+    withdraw.totalCount = BigInt.fromI32(0);
+    withdraw.totalGasUsed = BigInt.fromI32(0);
+
+    withdraw.save();
+    stats.save();
+  }
+
+  return stats;
+}
+
+export function handleWithdrawal(event: WithdrawalEvent): void {
+  const id = `${event.transaction.hash.toHex()}`;
+
+  let withdraw = WormWithdraw.load(id);
+
+  if (withdraw != null) {
+    return; // tx already processed
+  }
+
+  if (event.receipt === null) {
+    return; // we need the receipt to gas used
+  }
+
+  if (event.transaction.to === null) {
+    return; // contract creation tx, not a withdrawal from existing contract
+  }
+
+  if (!event.transaction.to!.equals(BETH_CONTRACT_ADDRESS)) {
+    return; // not a withdrawal from BETH contract
+  }
+
+  withdraw = new WormWithdraw(id);
+  withdraw.value = event.params.wad;
+
+  withdraw.blockNumber = event.block.number;
+  withdraw.timestamp = event.block.timestamp;
+  withdraw.txHash = event.transaction.hash;
+  withdraw.gasUsed = event.receipt!.gasUsed;
+  withdraw.gasPrice = event.transaction.gasPrice;
+
+  withdraw.save();
+
+  const stats = createOrLoadProtocolStats();
+  stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
+  stats.totalGasUsed = stats.totalGasUsed.plus(event.receipt!.gasUsed);
+
+  stats.save();
+
+  const operationStats = WormOperationStats.load(stats.withdraw);
+
+  if (operationStats != null) {
+    operationStats.totalCount = operationStats.totalCount.plus(BigInt.fromI32(1));
+    operationStats.totalGasUsed = operationStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    operationStats.save();
+  }
+}

--- a/subgraph/tests/worm/utils.ts
+++ b/subgraph/tests/worm/utils.ts
@@ -1,0 +1,17 @@
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+
+import { Withdrawal } from "../../generated/WETH/WETH";
+
+export function createWithdrawEvent(hash: Bytes, to: Address, wad: BigInt): Withdrawal {
+  const event = changetype<Withdrawal>(newMockEvent());
+  event.transaction.hash = hash;
+  event.transaction.to = to;
+
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("src", ethereum.Value.fromAddress(Address.zero())));
+  event.parameters.push(new ethereum.EventParam("wad", ethereum.Value.fromUnsignedBigInt(wad)));
+
+  return event;
+}

--- a/subgraph/tests/worm/weth-withdraw.test.ts
+++ b/subgraph/tests/worm/weth-withdraw.test.ts
@@ -1,0 +1,129 @@
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { assert, afterAll, describe, beforeAll, clearStore, test } from "matchstick-as/assembly/index";
+
+import { BETH_CONTRACT_ADDRESS, handleWithdrawal } from "../../src/worm/weth";
+
+import { createWithdrawEvent } from "./utils";
+
+const WITHDRAW_TRANSACTION_HASH = Bytes.fromHexString("0xa16081f360e3847006db660bae1c6d1b2e17ec2a");
+const AMOUNT = BigInt.fromI32(1000);
+
+const PROTOCOL_ID = "worm-protocol-stats";
+const WITHDRAW_OPERATION_ID = `${PROTOCOL_ID}-withdraw`;
+
+describe("WORM withdraw tests", () => {
+  describe("1 event 1 tx", () => {
+    beforeAll(() => {
+      const event = createWithdrawEvent(WITHDRAW_TRANSACTION_HASH, BETH_CONTRACT_ADDRESS, AMOUNT);
+
+      handleWithdrawal(event);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("WormWithdraw created", () => {
+      assert.entityCount("WormWithdraw", 1);
+    });
+
+    test("WormWithdraw values stored correctly", () => {
+      const id = WITHDRAW_TRANSACTION_HASH.toHexString();
+
+      assert.fieldEquals("WormWithdraw", id, "value", AMOUNT.toString());
+      assert.fieldEquals("WormWithdraw", id, "txHash", WITHDRAW_TRANSACTION_HASH.toHexString());
+    });
+
+    test("Protocol stats updated", () => {
+      assert.fieldEquals("WormProtocolStats", PROTOCOL_ID, "totalTxCount", "1");
+    });
+
+    test("Withdraw operation stats updated", () => {
+      assert.fieldEquals("WormOperationStats", WITHDRAW_OPERATION_ID, "totalCount", "1");
+    });
+  });
+
+  describe("2 events 1 tx", () => {
+    beforeAll(() => {
+      const event1 = createWithdrawEvent(WITHDRAW_TRANSACTION_HASH, BETH_CONTRACT_ADDRESS, AMOUNT);
+      const event2 = createWithdrawEvent(WITHDRAW_TRANSACTION_HASH, BETH_CONTRACT_ADDRESS, AMOUNT);
+
+      handleWithdrawal(event1);
+      handleWithdrawal(event2);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("Only one WormWithdraw created", () => {
+      assert.entityCount("WormWithdraw", 1);
+    });
+
+    test("Protocol stats updated only once", () => {
+      assert.fieldEquals("WormProtocolStats", PROTOCOL_ID, "totalTxCount", "1");
+    });
+
+    test("Withdraw operation stats updated only once", () => {
+      assert.fieldEquals("WormOperationStats", WITHDRAW_OPERATION_ID, "totalCount", "1");
+    });
+  });
+
+  describe("2 events 2 txs", () => {
+    beforeAll(() => {
+      const event1 = createWithdrawEvent(WITHDRAW_TRANSACTION_HASH, BETH_CONTRACT_ADDRESS, AMOUNT);
+      const event2 = createWithdrawEvent(
+        Bytes.fromHexString("0xb16081f360e3847006db660bae1c6d1b2e17ec3b"),
+        BETH_CONTRACT_ADDRESS,
+        AMOUNT,
+      );
+
+      handleWithdrawal(event1);
+      handleWithdrawal(event2);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("Two WormWithdraw created", () => {
+      assert.entityCount("WormWithdraw", 2);
+    });
+
+    test("Protocol stats updated twice", () => {
+      assert.fieldEquals("WormProtocolStats", PROTOCOL_ID, "totalTxCount", "2");
+    });
+
+    test("Withdraw operation stats updated twice", () => {
+      assert.fieldEquals("WormOperationStats", WITHDRAW_OPERATION_ID, "totalCount", "2");
+    });
+  });
+
+  describe("event not from BETH contract", () => {
+    beforeAll(() => {
+      const event = createWithdrawEvent(
+        WITHDRAW_TRANSACTION_HASH,
+        Address.fromString("0x0000000000000000000000000000000000000002"),
+        AMOUNT,
+      );
+
+      handleWithdrawal(event);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("No WormWithdraw created", () => {
+      assert.entityCount("WormWithdraw", 0);
+    });
+
+    test("No Protocol stats created", () => {
+      assert.entityCount("WormProtocolStats", 0);
+    });
+
+    test("No Withdraw operation stats created", () => {
+      assert.entityCount("WormOperationStats", 0);
+    });
+  });
+});


### PR DESCRIPTION
# What this PR does

1. Added WORM protocol to subgraph. It is worth pointing out that WORM does not have a singular unique event to identify the withdraw transaction (e.g. Withdraw, Unshield, Decrypt). It has a sequence of events emitted by the BETH contract that can be used to identify withdraw transactions

2. created the `logsMatchEvents` function to reuse in future protocol additions

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have supplied a PR description that explains what the PR does.
- [X] I have linked a github issue to the PR if one exists.
- [X] I ran and verified that all tests pass locally.
