### PR TITLE
feat(subgraph): add privacy pools event mappers

### DIFF
--- a/gas-benchmarks/src/subgraph/index.ts
+++ b/gas-benchmarks/src/subgraph/index.ts
@@ -1,6 +1,7 @@
 import type {
   HinkalProtocolStatsFragmentFragment,
   FluidkeyProtocolStatsFragmentFragment,
+  PrivacyPoolsProtocolStatsFragmentFragment,
   RailgunProtocolStatsFragmentFragment,
   TornadoCashProtocolStatsFragmentFragment,
 } from "../generated/graphql.js";
@@ -10,7 +11,8 @@ import { graphql } from "../generated/gql.js";
 export type TRootQuery = RailgunProtocolStatsFragmentFragment &
   TornadoCashProtocolStatsFragmentFragment &
   HinkalProtocolStatsFragmentFragment &
-  FluidkeyProtocolStatsFragmentFragment;
+  FluidkeyProtocolStatsFragmentFragment &
+  PrivacyPoolsProtocolStatsFragmentFragment;
 
 export const RootQuery = graphql(/* GraphQL */ `
   query RootQuery {
@@ -18,5 +20,6 @@ export const RootQuery = graphql(/* GraphQL */ `
     ...TornadoCashProtocolStatsFragment
     ...HinkalProtocolStatsFragment
     ...FluidkeyProtocolStatsFragment
+    ...PrivacyPoolsProtocolStatsFragment
   }
 `);

--- a/gas-benchmarks/src/subgraph/privacy-pools.ts
+++ b/gas-benchmarks/src/subgraph/privacy-pools.ts
@@ -1,0 +1,41 @@
+import { graphql } from "../generated/gql.js";
+
+export const PrivacyPoolsProtocolStatsFragment = graphql(/* GraphQL */ `
+  fragment PrivacyPoolsProtocolStatsFragment on Query {
+    privacyPoolsProtocolStats(id: "privacy-pools-protocol-stats") {
+      id
+      totalTxCount
+      totalGasUsed
+
+      shield {
+        id
+        totalCount
+        totalGasUsed
+        totalValue
+
+        shieldTokenStats {
+          id
+          tokenAddress
+          totalCount
+          totalGasUsed
+          totalValue
+        }
+      }
+
+      unshield {
+        id
+        totalCount
+        totalGasUsed
+        totalValue
+
+        unshieldTokenStats {
+          id
+          tokenAddress
+          totalCount
+          totalGasUsed
+          totalValue
+        }
+      }
+    }
+  }
+`);

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -2,7 +2,7 @@
 
 Build the required subgraph to fetch metrics data for the benchmarks.
 
-The current version of the deployed subgraph is `v0.0.10`.
+The current version of the deployed subgraph is `v0.0.13`.
 
 ## Build and deploy
 

--- a/subgraph/abis/privacy-pools/PrivacyPoolsEntrypointProxy.json
+++ b/subgraph/abis/privacy-pools/PrivacyPoolsEntrypointProxy.json
@@ -1,0 +1,1083 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AssetMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AssetPoolAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyRoot",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidEntrypointForPool",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFeeBPS",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidIPFSCIDLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPoolState",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidProcessooor",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidWithdrawalAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MinimumDepositAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NativeAssetNotAccepted",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NativeAssetTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoRootsAvailable",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PoolIsDead",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PoolNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PrecommitmentAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RelayFeeGreaterThanMax",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ScopePoolAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_depositor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_commitment",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newMinimumDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newVettingFeeBPS",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newMaxRelayFeeBPS",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolConfigurationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_scope",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_scope",
+        "type": "uint256"
+      }
+    ],
+    "name": "PoolRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolWindDown",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_root",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "_ipfsCID",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "RootUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_relayer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_feeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalRelayed",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      }
+    ],
+    "name": "assetConfig",
+    "outputs": [
+      {
+        "internalType": "contract IPrivacyPool",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minimumDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "vettingFeeBPS",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxRelayFeeBPS",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "associationSets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "root",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "ipfsCID",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_precommitment",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_commitment",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_precommitment",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_commitment",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_postman",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "latestRoot",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_root",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minimumDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_vettingFeeBPS",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxRelayFeeBPS",
+        "type": "uint256"
+      }
+    ],
+    "name": "registerPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "processooor",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IPrivacyPool.Withdrawal",
+        "name": "_withdrawal",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256[2]",
+            "name": "pA",
+            "type": "uint256[2]"
+          },
+          {
+            "internalType": "uint256[2][2]",
+            "name": "pB",
+            "type": "uint256[2][2]"
+          },
+          {
+            "internalType": "uint256[2]",
+            "name": "pC",
+            "type": "uint256[2]"
+          },
+          {
+            "internalType": "uint256[8]",
+            "name": "pubSignals",
+            "type": "uint256[8]"
+          }
+        ],
+        "internalType": "struct ProofLib.WithdrawProof",
+        "name": "_proof",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_scope",
+        "type": "uint256"
+      }
+    ],
+    "name": "relay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      }
+    ],
+    "name": "removePool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      }
+    ],
+    "name": "rootByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_root",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_scope",
+        "type": "uint256"
+      }
+    ],
+    "name": "scopeToPool",
+    "outputs": [
+      {
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minimumDepositAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_vettingFeeBPS",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxRelayFeeBPS",
+        "type": "uint256"
+      }
+    ],
+    "name": "updatePoolConfiguration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_root",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_ipfsCID",
+        "type": "string"
+      }
+    ],
+    "name": "updateRoot",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_precommitment",
+        "type": "uint256"
+      }
+    ],
+    "name": "usedPrecommitments",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "_used",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPrivacyPool",
+        "name": "_pool",
+        "type": "address"
+      }
+    ],
+    "name": "windDownPool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_recipient",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/subgraph/configuration/subgraph.mainnet.yaml
+++ b/subgraph/configuration/subgraph.mainnet.yaml
@@ -69,10 +69,11 @@ dataSources:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
       entities:
-        - HinkalShield
-        - HinkalUnshield
+        - HinkalShieldERC20
+        - HinkalShieldNative
+        - HinkalUnshieldERC20
+        - HinkalUnshieldNative
         - HinkalTransact
-        - HinkalTransaction
       abis:
         - name: HinkalPool
           file: ../abis/hinkal/HinkalPool.json
@@ -106,6 +107,36 @@ dataSources:
           handler: handleOperationRelayed
           receipt: true
       file: ../src/fluidkey/smart-account-relayer.ts
+
+  - kind: ethereum
+    name: PrivacyPoolsEntrypointProxy
+    network: mainnet
+    source:
+      address: "0x6818809EefCe719E480a7526D76bD3e561526b46"
+      abi: PrivacyPoolsEntrypointProxy
+      startBlock: 22153715
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - PrivacyPoolsDeposit
+        - PrivacyPoolsWithdrawal
+      abis:
+        - name: PrivacyPoolsEntrypointProxy
+          file: ../abis/privacy-pools/PrivacyPoolsEntrypointProxy.json
+      eventHandlers:
+        - event: Deposited(indexed address,indexed address,uint256,uint256)
+          handler: handleDeposit
+          receipt: true
+        - event: WithdrawalRelayed(indexed address,indexed address,indexed address,uint256,uint256)
+          handler: handleWithdrawal
+          receipt: true
+        - event: PoolRegistered(address,address,uint256)
+          handler: handlePoolRegistered
+        - event: PoolRemoved(address,address,uint256)
+          handler: handlePoolRemoved
+      file: ../src/privacy-pools/privacy-pools.ts
 
 templates:
   - kind: ethereum

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -202,6 +202,76 @@ type HinkalUnshieldERC20 @entity(immutable: true) {
   gasPrice: BigInt!
 }
 
+type PrivacyPoolsProtocolStats @entity(immutable: false) {
+  id: ID!
+  totalTxCount: BigInt!
+  totalGasUsed: BigInt!
+
+  shield: PrivacyPoolsOperationStats!
+  unshield: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsPool @entity(immutable: true) {
+  id: ID!
+  pool: Bytes!
+  asset: Bytes!
+}
+
+type PrivacyPoolsOperationStats @entity(immutable: false) {
+  id: ID!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  shieldTokenStats: [PrivacyPoolsShieldStats!]! @derivedFrom(field: "operationStats")
+  unshieldTokenStats: [PrivacyPoolsUnshieldStats!]! @derivedFrom(field: "operationStats")
+}
+
+type PrivacyPoolsShieldStats @entity(immutable: false) {
+  id: ID!
+  tokenAddress: Bytes!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  operationStats: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsUnshieldStats @entity(immutable: false) {
+  id: ID!
+  tokenAddress: Bytes!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  operationStats: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsDeposit @entity(immutable: true) {
+  id: ID!
+  tokenAddress: Bytes!
+  amount: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}
+
+type PrivacyPoolsWithdrawal @entity(immutable: true) {
+  id: ID!
+  tokenAddress: Bytes!
+  fee: BigInt!
+  amount: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}
+
 type RailgunProtocolStats @entity(immutable: false) {
   id: ID!
   totalTxCount: BigInt!

--- a/subgraph/schemas/privacy-pools.graphql
+++ b/subgraph/schemas/privacy-pools.graphql
@@ -1,0 +1,69 @@
+type PrivacyPoolsProtocolStats @entity(immutable: false) {
+  id: ID!
+  totalTxCount: BigInt!
+  totalGasUsed: BigInt!
+
+  shield: PrivacyPoolsOperationStats!
+  unshield: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsPool @entity(immutable: true) {
+  id: ID!
+  pool: Bytes!
+  asset: Bytes!
+}
+
+type PrivacyPoolsOperationStats @entity(immutable: false) {
+  id: ID!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  shieldTokenStats: [PrivacyPoolsShieldStats!]! @derivedFrom(field: "operationStats")
+  unshieldTokenStats: [PrivacyPoolsUnshieldStats!]! @derivedFrom(field: "operationStats")
+}
+
+type PrivacyPoolsShieldStats @entity(immutable: false) {
+  id: ID!
+  tokenAddress: Bytes!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  operationStats: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsUnshieldStats @entity(immutable: false) {
+  id: ID!
+  tokenAddress: Bytes!
+  totalCount: BigInt!
+  totalGasUsed: BigInt!
+  totalValue: BigInt!
+
+  operationStats: PrivacyPoolsOperationStats!
+}
+
+type PrivacyPoolsDeposit @entity(immutable: true) {
+  id: ID!
+  tokenAddress: Bytes!
+  amount: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}
+
+type PrivacyPoolsWithdrawal @entity(immutable: true) {
+  id: ID!
+  tokenAddress: Bytes!
+  fee: BigInt!
+  amount: BigInt!
+
+  blockNumber: BigInt!
+  timestamp: BigInt!
+  txHash: Bytes!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+}

--- a/subgraph/src/fluidkey/smart-account-relayer.ts
+++ b/subgraph/src/fluidkey/smart-account-relayer.ts
@@ -12,7 +12,7 @@ function createOrLoadProtocolStats(): FluidkeyProtocolStats {
   const id = "fluidkey-protocol-stats";
   let stats = FluidkeyProtocolStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new FluidkeyProtocolStats(id);
     stats.totalTxCount = BigInt.fromI32(0);
     stats.totalGasUsed = BigInt.fromI32(0);
@@ -34,7 +34,7 @@ function createOrLoadStealthToPublicStats(operationStatsId: string): FluidkeySte
   const id = operationStatsId;
   let stats = FluidkeyStealthToPublicStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new FluidkeyStealthToPublicStats(id);
     stats.operationStats = operationStatsId;
     stats.totalCount = BigInt.fromI32(0);

--- a/subgraph/src/hinkal/hinkal-pool.ts
+++ b/subgraph/src/hinkal/hinkal-pool.ts
@@ -22,7 +22,7 @@ function createOrLoadProtocolStats(): HinkalProtocolStats {
   const id = "hinkal-protocol-stats";
   let stats = HinkalProtocolStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalProtocolStats(id);
 
     stats.totalTxCount = BigInt.zero();
@@ -70,7 +70,7 @@ function createOrLoadShieldERC20TokenStats(tokenAddress: Bytes, operationStatsId
   const id = `hinkal-shield-${tokenAddress.toHex()}`;
   let stats = HinkalShieldERC20TokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalShieldERC20TokenStats(id);
     stats.operationStats = operationStatsId;
     stats.tokenAddress = tokenAddress;
@@ -88,7 +88,7 @@ function createOrLoadShieldNativeTokenStats(operationStatsId: string): HinkalShi
   const id = "hinkal-protocol-stats-shield-native-stats";
   let stats = HinkalShieldNativeTokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalShieldNativeTokenStats(id);
     stats.operationStats = operationStatsId;
     stats.totalCount = BigInt.fromI32(0);
@@ -104,7 +104,7 @@ function createOrLoadTransactTokenStats(operationStatsId: string): HinkalTransac
   const id = "hinkal-protocol-stats-transact-stats";
   let stats = HinkalTransactTokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalTransactTokenStats(id);
     stats.operationStats = operationStatsId;
     stats.totalCount = BigInt.fromI32(0);
@@ -123,7 +123,7 @@ function createOrLoadUnshieldERC20TokenStats(
   const id = `hinkal-unshield-${tokenAddress.toHex()}`;
   let stats = HinkalUnshieldERC20TokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalUnshieldERC20TokenStats(id);
     stats.operationStats = operationStatsId;
     stats.tokenAddress = tokenAddress;
@@ -141,7 +141,7 @@ function createOrLoadUnshieldNativeTokenStats(operationStatsId: string): HinkalU
   const id = "hinkal-protocol-stats-unshield-native-stats";
   let stats = HinkalUnshieldNativeTokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new HinkalUnshieldNativeTokenStats(id);
     stats.operationStats = operationStatsId;
     stats.totalCount = BigInt.fromI32(0);

--- a/subgraph/src/privacy-pools/privacy-pools.ts
+++ b/subgraph/src/privacy-pools/privacy-pools.ts
@@ -1,0 +1,221 @@
+/* eslint-disable no-underscore-dangle */
+import { BigInt, Bytes, store } from "@graphprotocol/graph-ts";
+
+import {
+  Deposited,
+  PoolRegistered,
+  PoolRemoved,
+  WithdrawalRelayed,
+} from "../../generated/PrivacyPoolsEntrypointProxy/PrivacyPoolsEntrypointProxy";
+import {
+  PrivacyPoolsProtocolStats,
+  PrivacyPoolsOperationStats,
+  PrivacyPoolsShieldStats,
+  PrivacyPoolsUnshieldStats,
+  PrivacyPoolsDeposit,
+  PrivacyPoolsWithdrawal,
+  PrivacyPoolsPool,
+} from "../../generated/schema";
+
+function createOrLoadProtocolStats(): PrivacyPoolsProtocolStats {
+  const id = "privacy-pools-protocol-stats";
+  let stats = PrivacyPoolsProtocolStats.load(id);
+
+  if (stats === null) {
+    stats = new PrivacyPoolsProtocolStats(id);
+    stats.totalTxCount = BigInt.fromI32(0);
+    stats.totalGasUsed = BigInt.fromI32(0);
+
+    const shieldStats = new PrivacyPoolsOperationStats(`${id}-shield`);
+    shieldStats.totalCount = BigInt.fromI32(0);
+    shieldStats.totalGasUsed = BigInt.fromI32(0);
+    shieldStats.totalValue = BigInt.fromI32(0);
+
+    const unshieldStats = new PrivacyPoolsOperationStats(`${id}-unshield`);
+    unshieldStats.totalCount = BigInt.fromI32(0);
+    unshieldStats.totalGasUsed = BigInt.fromI32(0);
+    unshieldStats.totalValue = BigInt.fromI32(0);
+
+    stats.shield = shieldStats.id;
+    stats.unshield = unshieldStats.id;
+
+    stats.save();
+    shieldStats.save();
+    unshieldStats.save();
+  }
+
+  return stats;
+}
+
+function createOrLoadShieldStats(tokenAddress: Bytes, operationStatsId: string): PrivacyPoolsShieldStats {
+  const id = `privacy-pools-shield-${tokenAddress.toHex()}`;
+  let stats = PrivacyPoolsShieldStats.load(id);
+
+  if (stats === null) {
+    stats = new PrivacyPoolsShieldStats(id);
+    stats.tokenAddress = tokenAddress;
+    stats.operationStats = operationStatsId;
+    stats.totalCount = BigInt.fromI32(0);
+    stats.totalGasUsed = BigInt.fromI32(0);
+    stats.totalValue = BigInt.fromI32(0);
+    stats.save();
+  }
+
+  return stats;
+}
+
+function createOrLoadUnshieldStats(tokenAddress: Bytes, operationStatsId: string): PrivacyPoolsUnshieldStats {
+  const id = `privacy-pools-unshield-${tokenAddress.toHex()}`;
+  let stats = PrivacyPoolsUnshieldStats.load(id);
+
+  if (stats === null) {
+    stats = new PrivacyPoolsUnshieldStats(id);
+    stats.tokenAddress = tokenAddress;
+    stats.operationStats = operationStatsId;
+    stats.totalCount = BigInt.fromI32(0);
+    stats.totalGasUsed = BigInt.fromI32(0);
+    stats.totalValue = BigInt.fromI32(0);
+    stats.save();
+  }
+
+  return stats;
+}
+
+export function handlePoolRegistered(event: PoolRegistered): void {
+  const id = event.params._pool.toHex();
+
+  const entity = new PrivacyPoolsPool(id);
+  entity.pool = event.params._pool;
+  entity.asset = event.params._asset;
+
+  entity.save();
+}
+
+export function handlePoolRemoved(event: PoolRemoved): void {
+  const id = event.params._pool.toHex();
+
+  const entity = PrivacyPoolsPool.load(id);
+
+  if (entity !== null) {
+    store.remove("PrivacyPoolsPool", id);
+  }
+}
+
+export function handleDeposit(event: Deposited): void {
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+
+  const deposit = new PrivacyPoolsDeposit(id);
+  const stats = createOrLoadProtocolStats();
+
+  stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
+
+  if (event.receipt !== null) {
+    stats.totalGasUsed = stats.totalGasUsed.plus(event.receipt!.gasUsed);
+  }
+
+  const shieldStats = PrivacyPoolsOperationStats.load(stats.shield);
+
+  if (shieldStats !== null) {
+    shieldStats.totalCount = shieldStats.totalCount.plus(BigInt.fromI32(1));
+    shieldStats.totalValue = shieldStats.totalValue.plus(event.params._amount);
+
+    if (event.receipt !== null) {
+      shieldStats.totalGasUsed = shieldStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    }
+
+    shieldStats.save();
+  }
+
+  stats.save();
+
+  const pool = PrivacyPoolsPool.load(event.params._pool.toHex());
+
+  if (pool === null) {
+    return;
+  }
+
+  deposit.tokenAddress = pool.asset;
+  deposit.amount = event.params._amount;
+
+  deposit.blockNumber = event.block.number;
+  deposit.timestamp = event.block.timestamp;
+  deposit.txHash = event.transaction.hash;
+
+  if (event.receipt !== null) {
+    deposit.gasUsed = event.receipt!.gasUsed;
+  }
+
+  deposit.gasPrice = event.transaction.gasPrice;
+
+  if (shieldStats !== null) {
+    const tokenStats = createOrLoadShieldStats(event.params._pool, shieldStats.id);
+
+    tokenStats.totalCount = tokenStats.totalCount.plus(BigInt.fromI32(1));
+    tokenStats.totalValue = tokenStats.totalValue.plus(event.params._amount);
+
+    if (event.receipt !== null) {
+      tokenStats.totalGasUsed = tokenStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    }
+
+    tokenStats.save();
+  }
+
+  deposit.save();
+}
+
+export function handleWithdrawal(event: WithdrawalRelayed): void {
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+
+  const withdrawal = new PrivacyPoolsWithdrawal(id);
+  const stats = createOrLoadProtocolStats();
+
+  stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
+
+  if (event.receipt !== null) {
+    stats.totalGasUsed = stats.totalGasUsed.plus(event.receipt!.gasUsed);
+  }
+
+  const unshieldStats = PrivacyPoolsOperationStats.load(stats.unshield);
+
+  if (unshieldStats !== null) {
+    unshieldStats.totalCount = unshieldStats.totalCount.plus(BigInt.fromI32(1));
+    unshieldStats.totalValue = unshieldStats.totalValue.plus(event.params._amount);
+
+    if (event.receipt !== null) {
+      unshieldStats.totalGasUsed = unshieldStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    }
+
+    unshieldStats.save();
+  }
+
+  stats.save();
+
+  withdrawal.tokenAddress = event.params._asset;
+  withdrawal.amount = event.params._amount;
+  withdrawal.fee = event.params._feeAmount;
+
+  withdrawal.blockNumber = event.block.number;
+  withdrawal.timestamp = event.block.timestamp;
+  withdrawal.txHash = event.transaction.hash;
+
+  if (event.receipt !== null) {
+    withdrawal.gasUsed = event.receipt!.gasUsed;
+  }
+
+  withdrawal.gasPrice = event.transaction.gasPrice;
+
+  if (unshieldStats !== null) {
+    const tokenStats = createOrLoadUnshieldStats(event.params._asset, unshieldStats.id);
+
+    tokenStats.totalCount = tokenStats.totalCount.plus(BigInt.fromI32(1));
+    tokenStats.totalValue = tokenStats.totalValue.plus(event.params._amount);
+
+    if (event.receipt !== null) {
+      tokenStats.totalGasUsed = tokenStats.totalGasUsed.plus(event.receipt!.gasUsed);
+    }
+
+    tokenStats.save();
+  }
+
+  withdrawal.save();
+}

--- a/subgraph/src/railgun/railgun-smart-wallet.ts
+++ b/subgraph/src/railgun/railgun-smart-wallet.ts
@@ -19,7 +19,7 @@ function createOrLoadProtocolStats(): RailgunProtocolStats {
   const id = "railgun-protocol-stats";
   let stats = RailgunProtocolStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RailgunProtocolStats(id);
     stats.totalTxCount = BigInt.fromI32(0);
     stats.totalGasUsed = BigInt.fromI32(0);
@@ -53,7 +53,7 @@ function createOrLoadShieldTokenStats(tokenAddress: Bytes, operationStatsId: str
   const id = `railgun-shield-${tokenAddress.toHex()}`;
   let stats = RailgunShieldTokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RailgunShieldTokenStats(id);
     stats.operationStats = operationStatsId;
     stats.tokenAddress = tokenAddress;
@@ -71,7 +71,7 @@ function createOrLoadUnshieldTokenStats(tokenAddress: Bytes, operationStatsId: s
   const id = `railgun-unshield-${tokenAddress.toHex()}`;
   let stats = RailgunUnshieldTokenStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RailgunUnshieldTokenStats(id);
     stats.operationStats = operationStatsId;
     stats.tokenAddress = tokenAddress;

--- a/subgraph/src/redact/confidential-eth.ts
+++ b/subgraph/src/redact/confidential-eth.ts
@@ -17,7 +17,7 @@ function createOrLoadProtocolStats(): RedactProtocolStats {
   const id = "redact-protocol-stats";
   let stats = RedactProtocolStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RedactProtocolStats(id);
     stats.totalTxCount = BigInt.fromI32(0);
     stats.totalGasUsed = BigInt.fromI32(0);
@@ -58,7 +58,7 @@ function createOrLoadShieldedStats(tokenAddress: Bytes | null, operationStatsId:
   const id = tokenAddress === null ? "redact-shield-native-eth" : tokenAddress.toHex();
   let stats = RedactShieldedStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RedactShieldedStats(id);
     stats.totalCount = BigInt.fromI32(0);
     stats.totalGasUsed = BigInt.fromI32(0);
@@ -79,7 +79,7 @@ function createOrLoadUnshieldedStats(operationStatsId: string): RedactUnshielded
   const id = "redact-unshield-native-eth";
   let stats = RedactUnshieldedStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new RedactUnshieldedStats(id);
     stats.totalCount = BigInt.fromI32(0);
     stats.totalGasUsed = BigInt.fromI32(0);

--- a/subgraph/src/tornado-cash/instance-registry.ts
+++ b/subgraph/src/tornado-cash/instance-registry.ts
@@ -12,7 +12,7 @@ export function handleInstanceStateUpdated(event: InstanceStateUpdated): void {
   let entity = TornadoCashInstance.load(id);
 
   if (state === ENABLED) {
-    if (entity == null) {
+    if (entity === null) {
       entity = new TornadoCashInstance(id);
       entity.address = address;
       entity.active = true;

--- a/subgraph/src/tornado-cash/tornado-instance.ts
+++ b/subgraph/src/tornado-cash/tornado-instance.ts
@@ -13,7 +13,7 @@ function createOrLoadTornadoStats(): TornadoCashProtocolStats {
   const id = "tornado-protocol-stats";
   let stats = TornadoCashProtocolStats.load(id);
 
-  if (stats == null) {
+  if (stats === null) {
     stats = new TornadoCashProtocolStats(id);
 
     stats.totalTxCount = BigInt.fromI32(0);
@@ -48,7 +48,7 @@ export function handleDeposit(event: Deposit): void {
   const instanceId = event.address.toHex();
   const instance = TornadoCashInstance.load(instanceId);
 
-  if (instance == null) {
+  if (instance === null) {
     return;
   }
 
@@ -81,7 +81,7 @@ export function handleDeposit(event: Deposit): void {
 
   const shieldedStats = TornadoCashOperationStats.load(stats.shield);
 
-  if (shieldedStats != null) {
+  if (shieldedStats !== null) {
     shieldedStats.totalCount = shieldedStats.totalCount.plus(BigInt.fromI32(1));
     shieldedStats.totalValue = shieldedStats.totalValue.plus(event.transaction.value);
 
@@ -99,7 +99,7 @@ export function handleWithdrawal(event: Withdrawal): void {
   const instanceId = event.address.toHex();
   const instance = TornadoCashInstance.load(instanceId);
 
-  if (instance == null) {
+  if (instance === null) {
     return;
   }
 
@@ -137,7 +137,7 @@ export function handleWithdrawal(event: Withdrawal): void {
 
   const unshieldedStats = TornadoCashOperationStats.load(stats.unshield);
 
-  if (unshieldedStats != null) {
+  if (unshieldedStats !== null) {
     unshieldedStats.totalCount = unshieldedStats.totalCount.plus(BigInt.fromI32(1));
     unshieldedStats.totalValue = unshieldedStats.totalValue.plus(event.transaction.value);
 

--- a/subgraph/tests/hinkal/hinkal-internal-transfer.test.ts
+++ b/subgraph/tests/hinkal/hinkal-internal-transfer.test.ts
@@ -1,0 +1,41 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+
+import { handleNewCommitment } from "../../src/hinkal/hinkal-pool";
+
+import { createNewCommitmentEvent, createNullifiedLog } from "./hinkal-utils";
+
+describe("Internal Transfer tests", () => {
+  beforeAll(() => {
+    const nullifiedLog = createNullifiedLog(Address.fromString("0x00000000000000000000000000000000000000ff"));
+    const newCommitmentEvent = createNewCommitmentEvent(nullifiedLog);
+
+    handleNewCommitment(newCommitmentEvent);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  test("HinkalTransact created", () => {
+    assert.entityCount("HinkalTransact", 1);
+  });
+
+  test("Protocol stats updated", () => {
+    assert.fieldEquals("HinkalProtocolStats", "hinkal-protocol-stats", "totalTxCount", "1");
+  });
+
+  test("Transact token stats updated", () => {
+    const id = "hinkal-protocol-stats-transact-stats";
+
+    assert.entityCount("HinkalTransactTokenStats", 1);
+
+    assert.fieldEquals("HinkalTransactTokenStats", id, "totalCount", "1");
+
+    assert.fieldEquals("HinkalTransactTokenStats", id, "totalGasUsed", "1");
+  });
+
+  test("Operation stats updated (transact)", () => {
+    assert.fieldEquals("HinkalOperationStats", "hinkal-protocol-stats-transact", "totalCount", "1");
+  });
+});

--- a/subgraph/tests/hinkal/hinkal-utils.ts
+++ b/subgraph/tests/hinkal/hinkal-utils.ts
@@ -16,6 +16,15 @@ export function createTransferLog(token: Address, from: Address, to: Address, am
   return log;
 }
 
+export function createNullifiedLog(contractAddress: Address): ethereum.Log {
+  const nullifiedLog = changetype<ethereum.Log>(newMockEvent());
+  nullifiedLog.address = contractAddress;
+  nullifiedLog.topics = [NULLIFIED_TOPIC];
+  nullifiedLog.data = Bytes.empty();
+
+  return nullifiedLog;
+}
+
 function addressToTopic(address: Address): Bytes {
   const padded = new Uint8Array(32);
   const bytes = address as Bytes;
@@ -27,7 +36,7 @@ function addressToTopic(address: Address): Bytes {
   return Bytes.fromUint8Array(padded);
 }
 
-export function createNewCommitmentEvent(transferLog: ethereum.Log): NewCommitment {
+export function createNewCommitmentEvent(log: ethereum.Log): NewCommitment {
   const event = changetype<NewCommitment>(newMockEvent());
 
   const commitmentLog = changetype<ethereum.Log>(newMockEvent());
@@ -35,7 +44,7 @@ export function createNewCommitmentEvent(transferLog: ethereum.Log): NewCommitme
   commitmentLog.data = Bytes.empty();
 
   const receipt = changetype<ethereum.TransactionReceipt>(newMockEvent());
-  receipt.logs = [transferLog, commitmentLog];
+  receipt.logs = [log, commitmentLog];
   receipt.gasUsed = BigInt.fromI32(1);
 
   event.receipt = receipt;
@@ -46,9 +55,7 @@ export function createNewCommitmentEvent(transferLog: ethereum.Log): NewCommitme
 export function createNullifiedEvent(logs: ethereum.Log[]): Nullified {
   const event = changetype<Nullified>(newMockEvent());
 
-  const nullifiedLog = changetype<ethereum.Log>(newMockEvent());
-  nullifiedLog.topics = [NULLIFIED_TOPIC];
-  nullifiedLog.data = Bytes.empty();
+  const nullifiedLog = createNullifiedLog(event.address);
 
   const receipt = changetype<ethereum.TransactionReceipt>(newMockEvent());
   receipt.logs = [logs[0], logs[1], nullifiedLog];

--- a/subgraph/tests/privacy-pools/privacy-pools-deposit.test.ts
+++ b/subgraph/tests/privacy-pools/privacy-pools-deposit.test.ts
@@ -1,0 +1,47 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+
+import { handleDeposit, handlePoolRegistered } from "../../src/privacy-pools/privacy-pools";
+
+import { createDepositEvent, createPoolRegisteredEvent } from "./privacy-pools-utils";
+
+describe("Deposit event tests", () => {
+  beforeAll(() => {
+    const pool = Address.fromString("0x0000000000000000000000000000000000000001");
+    const asset = Address.fromString("0x0000000000000000000000000000000000000002");
+    const depositor = Address.fromString("0x0000000000000000000000000000000000000003");
+
+    const registerEvent = createPoolRegisteredEvent(pool, asset);
+    handlePoolRegistered(registerEvent);
+
+    const depositEvent = createDepositEvent(depositor, pool, BigInt.fromI32(1), BigInt.fromI32(100));
+
+    handleDeposit(depositEvent);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  test("PrivacyPoolsDeposit created", () => {
+    assert.entityCount("PrivacyPoolsDeposit", 1);
+  });
+
+  test("Protocol stats updated", () => {
+    assert.fieldEquals("PrivacyPoolsProtocolStats", "privacy-pools-protocol-stats", "totalTxCount", "1");
+  });
+
+  test("Shield stats updated", () => {
+    const id = "privacy-pools-shield-0x0000000000000000000000000000000000000001";
+
+    assert.entityCount("PrivacyPoolsShieldStats", 1);
+    assert.fieldEquals("PrivacyPoolsShieldStats", id, "totalValue", "100");
+    assert.fieldEquals("PrivacyPoolsShieldStats", id, "totalCount", "1");
+    assert.fieldEquals("PrivacyPoolsShieldStats", id, "totalGasUsed", "1");
+  });
+
+  test("Operation stats updated (shield)", () => {
+    assert.fieldEquals("PrivacyPoolsOperationStats", "privacy-pools-protocol-stats-shield", "totalCount", "1");
+    assert.fieldEquals("PrivacyPoolsOperationStats", "privacy-pools-protocol-stats-shield", "totalValue", "100");
+  });
+});

--- a/subgraph/tests/privacy-pools/privacy-pools-pool.test.ts
+++ b/subgraph/tests/privacy-pools/privacy-pools-pool.test.ts
@@ -1,0 +1,36 @@
+import { Address } from "@graphprotocol/graph-ts";
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+
+import { handlePoolRegistered, handlePoolRemoved } from "../../src/privacy-pools/privacy-pools";
+
+import { createPoolRegisteredEvent, createPoolRemovedEvent } from "./privacy-pools-utils";
+
+describe("Pool events tests", () => {
+  beforeAll(() => {
+    const pool = Address.fromString("0x0000000000000000000000000000000000000001");
+    const asset = Address.fromString("0x0000000000000000000000000000000000000002");
+
+    const registerEvent = createPoolRegisteredEvent(pool, asset);
+    handlePoolRegistered(registerEvent);
+
+    const removeEvent = createPoolRemovedEvent(pool, asset);
+    handlePoolRemoved(removeEvent);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  test("Pool registered", () => {
+    const id = "0x0000000000000000000000000000000000000001";
+
+    assert.entityCount("PrivacyPoolsPool", 0);
+    assert.notInStore("PrivacyPoolsPool", id);
+  });
+
+  test("Pool removed", () => {
+    const id = "0x0000000000000000000000000000000000000001";
+
+    assert.notInStore("PrivacyPoolsPool", id);
+  });
+});

--- a/subgraph/tests/privacy-pools/privacy-pools-utils.ts
+++ b/subgraph/tests/privacy-pools/privacy-pools-utils.ts
@@ -1,0 +1,62 @@
+import { ethereum, BigInt, Address } from "@graphprotocol/graph-ts";
+import { newMockEvent } from "matchstick-as";
+
+import {
+  Deposited,
+  PoolRegistered,
+  PoolRemoved,
+  WithdrawalRelayed,
+} from "../../generated/PrivacyPoolsEntrypointProxy/PrivacyPoolsEntrypointProxy";
+
+export function createDepositEvent(depositor: Address, pool: Address, commitment: BigInt, amount: BigInt): Deposited {
+  const event = changetype<Deposited>(newMockEvent());
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("_depositor", ethereum.Value.fromAddress(depositor)));
+  event.parameters.push(new ethereum.EventParam("_pool", ethereum.Value.fromAddress(pool)));
+  event.parameters.push(new ethereum.EventParam("_commitment", ethereum.Value.fromUnsignedBigInt(commitment)));
+  event.parameters.push(new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(amount)));
+
+  return event;
+}
+
+export function createWithdrawalEvent(
+  relayer: Address,
+  recipient: Address,
+  asset: Address,
+  amount: BigInt,
+  fee: BigInt,
+): WithdrawalRelayed {
+  const event = changetype<WithdrawalRelayed>(newMockEvent());
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("_relayer", ethereum.Value.fromAddress(relayer)));
+  event.parameters.push(new ethereum.EventParam("_recipient", ethereum.Value.fromAddress(recipient)));
+  event.parameters.push(new ethereum.EventParam("_asset", ethereum.Value.fromAddress(asset)));
+  event.parameters.push(new ethereum.EventParam("_amount", ethereum.Value.fromUnsignedBigInt(amount)));
+  event.parameters.push(new ethereum.EventParam("_feeAmount", ethereum.Value.fromUnsignedBigInt(fee)));
+
+  return event;
+}
+
+export function createPoolRegisteredEvent(pool: Address, asset: Address): PoolRegistered {
+  const event = changetype<PoolRegistered>(newMockEvent());
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("_pool", ethereum.Value.fromAddress(pool)));
+  event.parameters.push(new ethereum.EventParam("_asset", ethereum.Value.fromAddress(asset)));
+  event.parameters.push(new ethereum.EventParam("_scope", ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))));
+
+  return event;
+}
+
+export function createPoolRemovedEvent(pool: Address, asset: Address): PoolRemoved {
+  const event = changetype<PoolRemoved>(newMockEvent());
+  event.parameters = [];
+
+  event.parameters.push(new ethereum.EventParam("_pool", ethereum.Value.fromAddress(pool)));
+  event.parameters.push(new ethereum.EventParam("_asset", ethereum.Value.fromAddress(asset)));
+  event.parameters.push(new ethereum.EventParam("_scope", ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))));
+
+  return event;
+}

--- a/subgraph/tests/privacy-pools/privacy-pools-withdrawal.test.ts
+++ b/subgraph/tests/privacy-pools/privacy-pools-withdrawal.test.ts
@@ -1,0 +1,44 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { assert, describe, test, clearStore, beforeAll, afterAll } from "matchstick-as/assembly/index";
+
+import { handleWithdrawal } from "../../src/privacy-pools/privacy-pools";
+
+import { createWithdrawalEvent } from "./privacy-pools-utils";
+
+describe("Privacy Pools Withdrawal event tests", () => {
+  beforeAll(() => {
+    const relayer = Address.fromString("0x0000000000000000000000000000000000000001");
+    const recipient = Address.fromString("0x0000000000000000000000000000000000000002");
+    const asset = Address.fromString("0x0000000000000000000000000000000000000003");
+
+    const event = createWithdrawalEvent(relayer, recipient, asset, BigInt.fromI32(100), BigInt.fromI32(5));
+
+    handleWithdrawal(event);
+  });
+
+  afterAll(() => {
+    clearStore();
+  });
+
+  test("PrivacyPoolsWithdrawal created", () => {
+    assert.entityCount("PrivacyPoolsWithdrawal", 1);
+  });
+
+  test("Protocol stats updated", () => {
+    assert.fieldEquals("PrivacyPoolsProtocolStats", "privacy-pools-protocol-stats", "totalTxCount", "1");
+  });
+
+  test("Unshield stats updated", () => {
+    const id = "privacy-pools-unshield-0x0000000000000000000000000000000000000003";
+
+    assert.entityCount("PrivacyPoolsUnshieldStats", 1);
+    assert.fieldEquals("PrivacyPoolsUnshieldStats", id, "totalValue", "100");
+    assert.fieldEquals("PrivacyPoolsUnshieldStats", id, "totalCount", "1");
+    assert.fieldEquals("PrivacyPoolsUnshieldStats", id, "totalGasUsed", "1");
+  });
+
+  test("Operation stats updated (unshield)", () => {
+    assert.fieldEquals("PrivacyPoolsOperationStats", "privacy-pools-protocol-stats-unshield", "totalCount", "1");
+    assert.fieldEquals("PrivacyPoolsOperationStats", "privacy-pools-protocol-stats-unshield", "totalValue", "100");
+  });
+});


### PR DESCRIPTION
# What this PR does

- [x] Add shield/unshield event mappers for erc20 and native tokens
- [x] Add register/remove event mappers for privacy pools to track assets
- [x] Add graphql client request
- [x] Add hinkal internal transfer tests
- [x] Use strict equality checks

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have supplied a PR description that explains what the PR does.
- [x] I have linked a github issue to the PR if one exists.
- [x] I ran and verified that all tests pass locally.
