### PR TITLE
Fix/citation lint

### DIFF
--- a/project-evaluations/scripts/research.ts
+++ b/project-evaluations/scripts/research.ts
@@ -148,7 +148,8 @@ async function evaluateProperty(
   else
     property.needsResearchReview =
       "Anthropic citations call returned no spans; the value and notes rest on the research summary rather than verifiable source text.";
-  console.log(`= ${value} [${citations.length} citations]\n`);
+  const valueStr = Array.isArray(value) ? value.join(", ") : value;
+  console.log(`= ${valueStr} [${citations.length} citations]\n`);
   return property;
 }
 

--- a/project-evaluations/scripts/utils/citations-response.ts
+++ b/project-evaluations/scripts/utils/citations-response.ts
@@ -3,7 +3,7 @@ import type { Property } from "../../src/types.js";
 import type { FetchedSource } from "./fetch-source.js";
 
 export interface ParsedResponse {
-  value: string;
+  value: string | string[];
   notes: string;
   citations: NonNullable<Property["citations"]>;
 }
@@ -26,20 +26,28 @@ export function parseCitationsResponse(response: Anthropic.Message, fetched: Fet
   for (const c of textBlocks.flatMap((b) => b.citations ?? [])) {
     if (c.type !== "char_location" || seen.has(c.cited_text)) continue;
     seen.add(c.cited_text);
-    citations.push({
-      cited_text: c.cited_text,
-      source: fetched[c.document_index]?.sourceUrl ?? fetched[0].sourceUrl,
-    });
+    const source = fetched[c.document_index]?.sourceUrl ?? fetched[0].sourceUrl;
+    const kind = inferCitationKind(source);
+    citations.push(kind ? { kind, cited_text: c.cited_text, source } : { cited_text: c.cited_text, source });
   }
 
   const input = (toolUse.input ?? {}) as { value?: unknown; insufficient_data?: boolean };
-  const value = Array.isArray(input.value)
-    ? JSON.stringify(input.value)
-    : typeof input.value === "string"
-      ? input.value
-      : undefined;
-  if (input.insufficient_data || !value) return { value: "INSUFFICIENT_DATA", notes, citations };
-  return { value, notes, citations };
+  const isNonEmpty = (v: unknown): v is string | string[] =>
+    typeof v === "string" ? v.length > 0 : Array.isArray(v) && v.length > 0;
+  if (input.insufficient_data || !isNonEmpty(input.value)) return { value: "INSUFFICIENT_DATA", notes, citations };
+  return { value: input.value, notes, citations };
+}
+
+const EXPLORER_HOST =
+  /^https?:\/\/(?:[a-z]+\.)*(?:etherscan\.io|basescan\.org|arbiscan\.io|polygonscan\.com|optimistic\.etherscan\.io|scrollscan\.com|lineascan\.build|solscan\.io|solana\.fm|bscscan\.com|snowtrace\.io)\//;
+const L2BEAT_HOST = /^https?:\/\/(?:www\.)?l2beat\.com\//;
+
+/** Infer the `kind` discriminator from a citation's source URL. Returns null when no kind applies
+ *  (the citation defaults to the "standard" case and omits the field). */
+function inferCitationKind(source: string): "explorer" | "l2beat" | null {
+  if (EXPLORER_HOST.test(source)) return "explorer";
+  if (L2BEAT_HOST.test(source)) return "l2beat";
+  return null;
 }
 
 /** Strip zero-width / soft-hyphen chars (docs sites embed these and the model copies them through),

--- a/project-evaluations/scripts/utils/lint-evaluations.ts
+++ b/project-evaluations/scripts/utils/lint-evaluations.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { evaluationSchema } from "../../src/data/evaluation-schema";
 import type { Property } from "../../src/types";
+import { readSourceCache, type SourceCache } from "./source-cache.js";
 
 type MaturityProperty = Extract<Property, { name: "Implementation maturity" }>;
 type UpgradeabilityProperty = Extract<Property, { name: "Upgradeability" }>;
@@ -121,7 +122,9 @@ function checkUpgradeability(file: string, property: UpgradeabilityProperty, leg
   }
 }
 
-function checkCitations(file: string, property: Property, legacy: boolean, issues: Issue[]) {
+const normaliseWhitespace = (s: string) => s.replace(/[‘’]/g, "'").replace(/[“”]/g, '"').replace(/\s+/g, " ").trim();
+
+function checkCitations(file: string, property: Property, legacy: boolean, sourceCache: SourceCache, issues: Issue[]) {
   if (legacy) return;
   const push = (rule: string, error: string) => issues.push({ file, property: property.name, rule, error });
 
@@ -133,15 +136,22 @@ function checkCitations(file: string, property: Property, legacy: boolean, issue
     }
     if (citedText.includes(" ,")) push("cited-text-punctuation", "space-before-comma");
     if (citedText.includes(" .")) push("cited-text-punctuation", "space-before-period");
+
+    const sourceText = sourceCache[citation.source];
+    if (typeof sourceText === "string" && !normaliseWhitespace(sourceText).includes(normaliseWhitespace(citedText))) {
+      push("cited-text-not-in-source", `cited_text not found in source-cache for ${citation.source}`);
+    }
   }
 }
 
 const issues: Issue[] = [];
 const files = readdirSync(evaluationsDir).filter((filename) => filename.endsWith(".json"));
 for (const file of files) {
-  const legacy = LEGACY_PROTOCOLS.has(file.replace(/\.json$/, ""));
+  const protocolId = file.replace(/\.json$/, "");
+  const legacy = LEGACY_PROTOCOLS.has(protocolId);
   const notesMax = legacy ? NOTES_MAX_LEGACY : NOTES_MAX_NEW;
   const json = JSON.parse(readFileSync(join(evaluationsDir, file), "utf-8"));
+  const sourceCache = legacy ? {} : readSourceCache(protocolId);
 
   parseSchema(file, json, issues);
 
@@ -154,7 +164,16 @@ for (const file of files) {
       checkDescription(file, property.name, property.notes, notesMax, issues);
     }
 
-    checkCitations(file, property, legacy, issues);
+    if (typeof property.needsResearchReview === "string" && property.needsResearchReview.includes(";")) {
+      issues.push({
+        file,
+        property: property.name,
+        rule: "semicolon-in-research-review",
+        error: "use full stop or em-dash",
+      });
+    }
+
+    checkCitations(file, property, legacy, sourceCache, issues);
 
     if (property.name === "Implementation maturity") {
       checkMaturityDate(file, property as MaturityProperty, legacy, issues);

--- a/project-evaluations/src/data/evaluation-schema.ts
+++ b/project-evaluations/src/data/evaluation-schema.ts
@@ -6,8 +6,10 @@ const propertyNameEnum = z.enum(propertyNames);
 const categoryEnum = z.enum(CATEGORIES);
 const evaluationStatusEnum = z.enum(["complete", "pending"]);
 
-/** Citation accepted on every property. */
+/** Citation accepted on every property. `kind` defaults to "standard" when absent —
+ *  only typed citations (explorer, docs, l2beat) need to set it explicitly. */
 const baseCitation = z.strictObject({
+  kind: z.enum(["docs", "explorer", "l2beat", "standard"]).optional(),
   cited_text: z.string().optional(),
   source: z.string(),
 });

--- a/project-evaluations/src/data/evaluations/aztec.json
+++ b/project-evaluations/src/data/evaluations/aztec.json
@@ -58,7 +58,7 @@
       "notes": "Asset identity is hidden for transfers that stay inside the private state model. Private state takes the form of notes — encrypted data that only the owner can decrypt — so any asset identifier and amount fields the contract puts inside the note are hidden. Only commitment hashes appear on-chain, leaving the asset type invisible to observers. Boundary interactions with specific public token contracts (deposits and withdrawals crossing into public state) remain observable at that interface.",
       "citations": [
         {
-          "cited_text": "Private state uses UTXOs, commonly called notes. Notes are encrypted pieces of data that only their owner can decrypt.",
+          "cited_text": ". Notes are encrypted pieces of data that only their owner can decrypt.",
           "source": "https://docs.aztec.network/developers/docs/foundational-topics/state_management"
         },
         {
@@ -96,10 +96,12 @@
       "notes": "An Aztec transaction is final when its epoch proof is verified on L1. A single proof can cover one checkpoint (1m 12s) up to one epoch (38m 24s = 2,304 seconds), and the epoch root proof is verified by the HonkVerifier contract before the proven checkpoint is advanced. Worst-case for inclusion is one full epoch — Ethereum L1 finality (~13 minutes) sits on top before the proof transaction itself is irreversible.",
       "citations": [
         {
+          "kind": "l2beat",
           "cited_text": "Each epoch root proof is verified by the HonkVerifier smart contract on Ethereum before the proven checkpoint number is advanced and the epoch outbox state root is inserted into the Outbox.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "a single proof can cover one Checkpoint (1m 12s) to one epoch (38m 24s).",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
@@ -146,10 +148,11 @@
           "source": "https://docs.aztec.network/participate/basics/bridging"
         },
         {
-          "cited_text": "first checkpoint's messages tree is always empty because there has to be a 1 checkpoint lag to prevent sequencer DOS attacks",
+          "cited_text": " empty because there has to be a 1 checkpoint lag to prevent sequencer DOS attacks",
           "source": "https://docs.aztec.network/developers/docs/foundational-topics/ethereum-aztec-messaging/inbox"
         },
         {
+          "kind": "l2beat",
           "cited_text": "a single proof can cover one Checkpoint (1m 12s) to one epoch (38m 24s).",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
@@ -165,6 +168,7 @@
           "source": "https://docs.aztec.network/participate/basics/bridging"
         },
         {
+          "kind": "l2beat",
           "cited_text": "a single proof can cover one Checkpoint (1m 12s) to one epoch (38m 24s). Unproven checkpoints are pruned after the proof submission window of 1h 16m expires.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
@@ -180,14 +184,17 @@
       "notes": "Aztec's sequencer set is permissionless — joining requires staking 200K AZTEC — and each epoch samples a 48-member committee from the active set of 3,548 sequencers, so no single party holds inclusion authority. If the sampled committee censors, anyone bonding 332M AZTEC joins an escape-hatch candidate set, and every 2d 23h a candidate is pseudo-randomly selected to propose and prove checkpoints autonomously. Inclusion is probabilistic rather than guaranteed within a fixed deadline.",
       "citations": [
         {
-          "cited_text": "Joining the sequencer set is permissionless and requires staking 200 K AZTEC. For each epoch, the rollup samples a 48-member committee from the active sequencer set of 3548.",
+          "kind": "l2beat",
+          "cited_text": "Joining the sequencer set is permissionless and requires staking 200 K AZTEC. For each epoch, the rollup samples a 48-member committee from the active sequencer set of 3548",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "anyone who bonds 332 M AZTEC will join the escape hatch candidate set. Every 2d 23h, a candidate is pseudo-randomly selected to propose and prove checkpoints fully autonomously.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "All censorship resistance tools that are part of the protocol rely on probabilistic inclusion.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
@@ -199,14 +206,17 @@
       "notes": "Aztec's sequencer and prover networks are part of the protocol itself rather than an external service: anyone can join the permissionless sequencer set by staking 200K AZTEC, and proving is permissionless too. The only external dependency is Ethereum L1, which provides data availability (EIP-4844 blobs whose commitments are revalidated by the epoch proof) and proof verification. No additional off-protocol committee, oracle, or relayer network is required for transfers.",
       "citations": [
         {
-          "cited_text": "Joining the sequencer set is permissionless and requires staking 200 K AZTEC. For each epoch, the rollup samples a 48-member committee from the active sequencer set of 3548.",
+          "kind": "l2beat",
+          "cited_text": "Joining the sequencer set is permissionless and requires staking 200 K AZTEC. For each epoch, the rollup samples a 48-member committee from the active sequencer set of 3548",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
-          "cited_text": "Proving is permissionless, and a single proof can cover one Checkpoint (1m 12s) to one epoch (38m 24s).",
+          "kind": "l2beat",
+          "cited_text": ", and a single proof can cover one Checkpoint (1m 12s) to one epoch (38m 24s).",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "Each checkpoint proposal includes EIP-4844 blob commitments that are checked against the blob hashes in the proposing transaction.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
@@ -218,14 +228,17 @@
       "notes": "Users can exit through a censorship-resistant fallback, but inclusion is probabilistic rather than guaranteed within a fixed deadline. If sampled committees censor, anyone who bonds 332M AZTEC joins an escape-hatch candidate set, and every 2d 23h a candidate is pseudo-randomly selected to propose and prove checkpoints autonomously. Users have 10 days to exit funds against an unwanted upgrade, with a 1-month upgrade delay, and withdrawal inclusion is simulated to take up to 20 days.",
       "citations": [
         {
+          "kind": "l2beat",
           "cited_text": "anyone who bonds 332 M AZTEC will join the escape hatch candidate set. Every 2d 23h, a candidate is pseudo-randomly selected to propose and prove checkpoints fully autonomously.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
-          "cited_text": "Users have 10d to exit funds in case of an unwanted upgrade. There is a 1mo delay before an upgrade is applied, and withdrawal inclusion is simulated to take up to 20d to be processed.",
+          "kind": "l2beat",
+          "cited_text": "Users have 10d to exit funds in case of an unwanted upgrade. There is a 1mo delay before an upgrade is applied, and withdrawal inclusion ",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "The project passes the walkaway test : users can exit in the presence of malicious operators even if the Security Council disappears.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
@@ -241,11 +254,13 @@
           "source": "https://docs.aztec.network/participate/governance"
         },
         {
-          "cited_text": "The smart contract code of Rollup, its verifier and its canonical messaging contracts cannot be changed. However, Governance owns critical permissions for configuration parameters",
+          "kind": "l2beat",
+          "cited_text": ", its verifier and its canonical messaging contracts cannot be changed. However, Governance owns critical permissions for configuration parameters",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
-          "cited_text": "Total standard delay from proposal to execution: 1mo 10d.",
+          "kind": "l2beat",
+          "cited_text": "Total standard delay from proposal to execution: 1mo 10d",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
       ],
@@ -295,6 +310,7 @@
           "source": "https://aztec.network/blog/announcing-the-alpha-network"
         },
         {
+          "kind": "explorer",
           "source": "https://etherscan.io/address/0x603bb2c05D474794ea97805e8De69bCcFb3bCA12",
           "contract_address": "0x603bb2c05D474794ea97805e8De69bCcFb3bCA12",
           "date": "2025-11-13"
@@ -307,10 +323,12 @@
       "notes": "Aztec's proving stack relies on classical elliptic-curve cryptography that is broken by Shor's algorithm. State validation uses SNARKs — succinct zero-knowledge proofs requiring a trusted setup — and L1 verification is performed by a HonkVerifier contract running Barretenberg's UltraHonk. The PLONK family relies on pairing-based elliptic-curve assumptions that do not survive a quantum adversary, and squisher circuits compress proofs into Standard Plonk or Fflonk with no lattice fallback.",
       "citations": [
         {
-          "cited_text": "SNARKs are succinct zero knowledge proofs that ensure state correctness, but require trusted setup.",
+          "kind": "l2beat",
+          "cited_text": "SNARKs are succinct zero knowledge proofs that ensure state correctness, but require trusted setup",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "PROVER\n\nBarretenberg \n\nTrusted Setups\n\nPlonk: UltraHonk\n\nOnchain verifier\n\nHonkVerifier",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
@@ -420,10 +438,12 @@
           "source": "https://docs.aztec.network/developers/docs/foundational-topics/advanced/circuits/rollup_circuits"
         },
         {
+          "kind": "l2beat",
           "cited_text": "Each epoch root proof is verified by the HonkVerifier smart contract on Ethereum before the proven checkpoint number is advanced",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         },
         {
+          "kind": "l2beat",
           "cited_text": "Each update to the system state must be accompanied by a ZK proof that ensures that the new state was derived by correctly applying a series of valid user transactions to the previous state.",
           "source": "https://l2beat.com/scaling/projects/aztecnetwork"
         }
@@ -435,7 +455,7 @@
       "notes": "The Aztec monorepo houses all protocol components — the Barretenberg ZK prover backend (which also houses the Aztec VM), Solidity L1 rollup contracts, Noir code for Aztec contracts and protocol circuits, and TypeScript client and backend code — under a single repository. The codebase is released under the Apache License, Version 2.0, an OSI-approved open source licence covering the prover, contracts, circuits, and SDK together.",
       "citations": [
         {
-          "cited_text": "barretenberg: The ZK prover backend that provides succinct verifiability for Aztec. Also houses the Aztec VM. l1-contracts: Solidity code for the Ethereum contracts that process rollups",
+          "cited_text": ": Solidity code for the Ethereum contracts that process rollups",
           "source": "https://github.com/AztecProtocol/aztec-packages"
         },
         {
@@ -492,7 +512,7 @@
       "notes": "Aztec's private state follows a UTXO model: notes are encrypted pieces of data that only their owner can decrypt. Commitments live in an append-only Merkle structure and users prove they know the note preimage when updating private state. Spending consumes a record by publishing a nullifier — an associated nullifier is added to a nullifier set, computed so observers cannot link it to a state record without the owner's keys. Public state is account-based.",
       "citations": [
         {
-          "cited_text": "Private state uses UTXOs, commonly called notes. Notes are encrypted pieces of data that only their owner can decrypt.",
+          "cited_text": ". Notes are encrypted pieces of data that only their owner can decrypt.",
           "source": "https://docs.aztec.network/developers/docs/foundational-topics/state_management"
         },
         {
@@ -538,7 +558,7 @@
           "source": "https://docs.aztec.network/developers/overview"
         },
         {
-          "cited_text": "Private functions from other contracts can be called either regularly or statically by using self.call() and self.view().",
+          "cited_text": "Private functions from other contracts can be called either regularly or statically by using self.call() and self.view()",
           "source": "https://docs.aztec.network/developers/docs/foundational-topics/call_types"
         }
       ]

--- a/project-evaluations/src/data/evaluations/intmax.json
+++ b/project-evaluations/src/data/evaluations/intmax.json
@@ -168,10 +168,12 @@
       "needsResearchReview": "Proving system requires citation",
       "citations": [
         {
+          "kind": "l2beat",
           "cited_text": "INTMAX Whitepaper \n\n7\nState validation \n\nINTMAX uses validity proofs to ensure that users cannot withdraw more than they have. For every transfer made, a ZK proof is required to prove the amount that has been transferred to be subtracted from the sender’s balance. ",
           "source": "https://l2beat.com/scaling/projects/intmax"
         },
         {
+          "kind": "l2beat",
           "cited_text": "Sequencer failure\n\nSelf sequence\n\nIn the event of a sequencer failure, users can force transactions to be included in the project’s chain by sending them to L1 . There can be up to a 7d delay on this operation. Proposing new blocks requires creating ZK proofs.\n\n",
           "source": "https://l2beat.com/scaling/projects/intmax"
         }


### PR DESCRIPTION
# What this PR does

- New lint check that every cited_text actually appears in its cited source
- Add a kind field on citations (docs/explorer/l2beat/standard)
- Set kind automatically when parsing known explorer and L2BEAT sources
- Let multi-select citation values be a string or an array, and log them safely
- Backfill kind and fix made-up quotes on aztec and intmax

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have supplied a PR description that explains what the PR does.
- [x] I have linked a github issue to the PR if one exists.
- [x] I ran and verified that all tests pass locally.
