### PR TITLE
Feat/eval client indexing

### DIFF
--- a/project-evaluations/.claude/skills/property-rules-state-model/SKILL.md
+++ b/project-evaluations/.claude/skills/property-rules-state-model/SKILL.md
@@ -21,7 +21,12 @@ For services with no protocol contracts at all — off-chain routing aggregators
 
 ## Client-side indexing
 
-(no property-specific rule yet — apply cross-cutting rules)
+Options: `Scanning`, `No Scanning`. Binary, and device-centric: must the user's own device scan the chain (trial-decrypting notes / outputs) to discover its funds?
+
+- `Scanning` — the device scans, whether full-chain or reduced with view-tags / filters (Monero, Zcash, Railgun, Aztec, stealth-address wallets watching for incoming payments).
+- `No Scanning` — the device does not scan. different cases qualify: secret-note recall (Tornado, Privacy Pools), direct account / balance lookup (encrypted-ERC20 and account-based ledgers — redact, tongo, scroll-cloak), and discovery delegated to an off-chain indexer / service that scans on the device's behalf (anoma-pay, bermudabay).
+
+Delegated / indexer-assisted discovery is `No Scanning` because the property asks what the _device_ does — but note it, since delegation adds a trust dependency (the indexer may see the user's discovery / viewing key) that the binary label does not capture. Do NOT use the old `Always scanning` / `Partial scanning` / `No scanning` wording.
 
 ## Private State Scalability
 

--- a/project-evaluations/src/data/evaluations/anoma-pay.json
+++ b/project-evaluations/src/data/evaluations/anoma-pay.json
@@ -388,7 +388,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Partial scanning",
+      "value": "No Scanning",
       "notes": "Balance discovery relies on an off-chain indexer service rather than full local chain scanning. The client submits its discovery private key with a list of contracts to the indexer, which returns the resources and tags addressed to that key across the requested chain IDs and contract addresses. The device runs no continuous block-by-block scan itself, but it must still poll the indexer per contract to assemble its resource set, making discovery server-assisted rather than trustless.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/aztec.json
+++ b/project-evaluations/src/data/evaluations/aztec.json
@@ -485,7 +485,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Partial scanning",
+      "value": "Scanning",
       "notes": "The PXE performs targeted tag-based lookups rather than scanning every log. The contract calls fetchTaggedLogs, and the PXE computes tags for every (sender, recipient) pair it knows about and queries the node for matching logs. Discovery is bounded by a sliding window with scanning extending from the aged index to a short range beyond the finalized index. Coverage is limited to registered counterparties: the PXE must know the sender's address in advance to compute the shared tagging secret.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/bermudabay.json
+++ b/project-evaluations/src/data/evaluations/bermudabay.json
@@ -412,7 +412,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "A separate chain-state service periodically downloads the most recent chain state via scheduled GitHub Actions, producing pre-indexed snapshots that the SDK ingests. The client SDK runs a single bootstrap synchronization step that loads this snapshot before performing ZK proving, rather than scanning every block itself. The indexing work is performed by the chain-state crawler service so the end user devices do not need to be constantly scanning on-chain events.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/blanksquare.json
+++ b/project-evaluations/src/data/evaluations/blanksquare.json
@@ -349,7 +349,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "The client syncs the latest Shielder state and constructs proofs locally. No server-side index keyed to the user is documented. The WASM cryptography engine drives both proving and chain scanning.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/curvy.json
+++ b/project-evaluations/src/data/evaluations/curvy.json
@@ -414,7 +414,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "The Curvy App, using the open-source Curvy SDK, starts syncing notes from the public Notes Registry immediately upon starting, and the SDK simultaneously scans the synced notes with the user's private keys to detect which notes are secretly in their ownership and to decrypt their balances. Note ownership is completely hidden from on-chain observers, which means continuous scanning with private keys is required to identify which notes belong to the user. The SDK must attempt decryption on all notes because there is no public index by recipient address.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/fluidkey.json
+++ b/project-evaluations/src/data/evaluations/fluidkey.json
@@ -145,7 +145,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "Continuous blockchain scanning is required because funds arrive at unlinkable stealth addresses. Fluidkey performs this scanning server-side using the shared viewing key node and notifies users when funds arrive.",
       "url": "https://docs.fluidkey.com/technical-documentation/ens-offchain-resolver#detailed-privacy-implications"
     },

--- a/project-evaluations/src/data/evaluations/hinkal.json
+++ b/project-evaluations/src/data/evaluations/hinkal.json
@@ -201,7 +201,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Partial scanning",
+      "value": "Scanning",
       "notes": "Users must scan chain events to discover incoming stealth transfers and reconstruct their shielded balance. Hinkal provides tooling (Hinkal Receive) for SDK integrators to build this scanning component. The wallet performs scanning internally for events related to the user's stealth addresses.",
       "url": "https://hinkal-team.gitbook.io/hinkal/hinkal-receive/features"
     },

--- a/project-evaluations/src/data/evaluations/houdiniswap.json
+++ b/project-evaluations/src/data/evaluations/houdiniswap.json
@@ -412,7 +412,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Houdini Swap requires no client-side chain scanning. Balances on the source and destination accounts are held in standard wallet addresses readable by any block explorer or wallet software. with no notes, commitments, or encrypted state to decrypt or track.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/intmax.json
+++ b/project-evaluations/src/data/evaluations/intmax.json
@@ -194,7 +194,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Transactions are shared peer-to-peer from the sender to the recipient. The recipient needs to verify a ZK proof in order to update its own client-side state. Only salted hashes of the transactions are published on-chain in order to help receivers get track of the global state and the unused notes (UTXOS).",
       "url": "https://docs.network.intmax.io/developers-hub/core-concepts/rollup-architecture#zk-proof-propagation-p2p"
     },

--- a/project-evaluations/src/data/evaluations/mirage.json
+++ b/project-evaluations/src/data/evaluations/mirage.json
@@ -404,7 +404,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "No scanning is required on the client side. Recipients receive funds through a direct on-chain token transfer from a node created wallet, which appears as a regular address sending them tokens, so their wallet picks it up as any ordinary incoming transfer.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/monero.json
+++ b/project-evaluations/src/data/evaluations/monero.json
@@ -158,7 +158,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Partial scanning",
+      "value": "Scanning",
       "notes": "Stealth addresses mean every transaction output is sent to a unique one-time public key. To detect incoming funds, wallets must scan each block and test every transaction output against the user's private view key and public spend key. This scanning occurs when the wallet is online and syncing  - if offline, the wallet must catch up on missed blocks when it reconnects.",
       "url": "https://www.getmonero.org/resources/moneropedia/transaction.html"
     },

--- a/project-evaluations/src/data/evaluations/nullmask.json
+++ b/project-evaluations/src/data/evaluations/nullmask.json
@@ -410,7 +410,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "User devices (via the RPC proxy) must continuously scan the chain to identify incoming notes, since ownership is not indexed by recipient address. The RPC proxy handles balance tracking by scanning the blockchain for new notes, trial-decrypting them, and maintaining shielded balances, with a dedicated notes scanner service that monitors blockchain events for incoming notes.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/privacy-pools.json
+++ b/project-evaluations/src/data/evaluations/privacy-pools.json
@@ -170,7 +170,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Users withdraw funds by providing their secret note directly, without needing to scan the blockchain. The official UI displays the user's deposits and amounts, but this is based on locally stored note data rather than scanning.",
       "url": "https://docs.privacypools.com/protocol/withdrawal#withdrawal-steps"
     },

--- a/project-evaluations/src/data/evaluations/railgun.json
+++ b/project-evaluations/src/data/evaluations/railgun.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Partial scanning",
+      "value": "Scanning",
       "notes": "While generating the most up-to-date merkle tree, each commitment leaf (which represents a transaction) must be synced and decrypted in order to build a RAILGUN wallet’s private balance. This syncing process can take a few minutes. Once the sync is complete, UTXO token balances are aggregated into a user’s balance.",
       "url": "https://docs.railgun.org/developer-guide/wallet/private-balances"
     },

--- a/project-evaluations/src/data/evaluations/redact.json
+++ b/project-evaluations/src/data/evaluations/redact.json
@@ -204,7 +204,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Since Redact uses an account-based model with encrypted balances stored directly as contract state, users can retrieve their encrypted balance directly from the contract without scanning past blockchain events.",
       "url": "https://docs.redact.money/using-redact/confidential-balances-wallet"
     },

--- a/project-evaluations/src/data/evaluations/scroll-cloak.json
+++ b/project-evaluations/src/data/evaluations/scroll-cloak.json
@@ -442,7 +442,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Account holders retrieve their data via authenticated JSON-RPC calls to the operator's gateway, with a SIWE-derived JWT scoping access to their own account. Balances and transactions come from the operator's permissioned RPC rather than being reconstructed from on-chain commitments — the client does not trial-decrypt or sweep the chain.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/tongo.json
+++ b/project-evaluations/src/data/evaluations/tongo.json
@@ -166,7 +166,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "Because Tongo uses an account-based model with balances stored directly as contract state, users can retrieve their encrypted balance directly from the contract without scanning past blockchain events or transactions.",
       "url": "https://docs.tongo.cash/sdk/accounts.html"
     },

--- a/project-evaluations/src/data/evaluations/tornado-cash.json
+++ b/project-evaluations/src/data/evaluations/tornado-cash.json
@@ -165,7 +165,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "You need to manually input your private note in order to be able to withdraw funds. In case of using a Note Account, the encrypted backup is stored in a smart contract storage so it is easily accessible without scanning past transactions",
       "url": "https://docs.tornadocash.eth.limo/tornado-cash-classic/deposit-withdraw.html"
     },

--- a/project-evaluations/src/data/evaluations/umbra-cash.json
+++ b/project-evaluations/src/data/evaluations/umbra-cash.json
@@ -351,7 +351,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "Recipients must scan every announcement event on the protocol contract and try-decrypt each ciphertext with their viewing key to find payments addressed to them. The client library queries per-chain subgraphs for efficiency, with RPC log queries as the fallback. Indexing is required client-side — there is no in-protocol discovery service.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/worm.json
+++ b/project-evaluations/src/data/evaluations/worm.json
@@ -256,7 +256,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "No scanning",
+      "value": "No Scanning",
       "notes": "WORM ERC20 tokens (BETH and WORM) have balances tracked on-chain through the Ethereum state so there is no need for client-side scanning. When users want to mint BETH through private proof-of-burn proofs, they generate the zk-proof on the UI using their recovery file containing their burnKey and receiver address. These process has to be performed per burn transaction. There is no mechanism to show privately burn balances on the WORM UI so there is no client-side indexing or scanning. Users have to keep track of their burn transaction data on their own.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/zcash.json
+++ b/project-evaluations/src/data/evaluations/zcash.json
@@ -390,7 +390,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "Shielded transactions reveal no metadata about the sender or receiver, users must scan the block chain for relevant transactions using viewing keys. Every valid block with non-coinbase transactions will need to be checked and its transactions trial-decrypted with registered incoming viewing keys to see if any notes have been received by the key's owner and if any notes have already been spent elsewhere. Unlike a transparent blockchain with public transactions, a full node must have online access to viewing keys to scan the chain.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/zerc20.json
+++ b/project-evaluations/src/data/evaluations/zerc20.json
@@ -402,7 +402,7 @@
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "Users must scan the chain to reconstruct the off-chain Merkle tree from on-chain hash chain commitments. The protocol uses gas-efficient hash chains on-chain and requires off-chain Poseidon-based Merkle tree reconstruction to generate withdrawal proofs. No alternative mechanism for balance tracking without chain scanning is described in the protocol design.",
       "citations": [
         {

--- a/project-evaluations/src/data/schema.ts
+++ b/project-evaluations/src/data/schema.ts
@@ -310,9 +310,9 @@ export const PROPERTY_DEFINITIONS: PropertyContent[] = [
     name: "Client-side indexing",
     group: "State",
     description: "Whether user devices must continuously scan the chain to track balances or accounts",
-    metric: "Always scanning / Partial scanning / No scanning",
+    metric: "Scanning / No Scanning",
     inputType: "select",
-    options: ["Always scanning", "Partial scanning", "No scanning"],
+    options: ["Scanning", "No Scanning"],
   },
   {
     name: "Private state model",


### PR DESCRIPTION
# What this PR does

- reduce client-side indexing to binary choice
- update skill
- anoma changed to no scanning since third party indexer does the scanning

Partial scanning is currently ambiguous and could capture multiple axes: it could capture device type, or performance of scanning. This change simplifies this property by only having scanning and not scanning as options

Ways we can break this down:

1. Binary choice (this PR): Scanning / No Scanning, explain nuance in the note. Simple, but doesn't capture all nuance

2. Three options based on who scans — Device / Delegated / No scan. Captures which device + trust boundary (delegated = a third party indexer scans)

3. Three options based on how much is scanned — Full / Filtered / No scan. Captures the full scan vs view-tag differences which impacts performance

To avoid a more significant re-analysis at this stage when don't have much time, I opted to use the binary choice. We can revisit this in the future if we want to

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have supplied a PR description that explains what the PR does.
- [x] I have linked a github issue to the PR if one exists.
- [x] I ran and verified that all tests pass locally.
