### PR TITLE
Feat/eval time display

### DIFF
--- a/project-evaluations/src/data/evaluations/intmax.json
+++ b/project-evaluations/src/data/evaluations/intmax.json
@@ -54,8 +54,8 @@
     },
     {
       "name": "Time-to-finality",
-      "value": "3300",
-      "notes": "Intmax is an zkRollup (could be considered a L3) settling on Scroll (L2) which settles on Ethereum (L1). Funds are stored on Ethereum. Finality depends on how long it takes for validity proofs to be submitted and verified. Scroll's finality time (~43 minutes as of writing) is the primary bottleneck, as Intmax blocks are submitted to Scroll.",
+      "value": "3600",
+      "notes": "Intmax is an zkRollup (could be considered a L3) settling on Scroll (L2) which settles on Ethereum (L1). Funds are stored on Ethereum. Finality depends on how long it takes for validity proofs to be submitted and verified. Scroll's proof-submission and state-update interval (~1 hour according to L2BEAT at the time of writing) is the primary bottleneck, as Intmax blocks are submitted to Scroll.",
       "url": "https://l2beat.com/scaling/projects/scroll#liveness",
       "needsResearchReview": "Not verified — Intmax block-builder delay unknown"
     },

--- a/project-evaluations/src/data/evaluations/nullmask.json
+++ b/project-evaluations/src/data/evaluations/nullmask.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "Deposit time",
-      "value": "15-30 seconds",
+      "value": "15-30",
       "notes": "When the user makes a deposit, the funds are held by the contract and a pending event is emitted. A guard service then screens the depositor address and either accepts or rejects it. This screening gates acceptance into the Merkle tree. It usually takes 15-30 seconds but it depends on the guard service.",
       "citations": [
         {

--- a/project-evaluations/src/data/evaluations/zcash.json
+++ b/project-evaluations/src/data/evaluations/zcash.json
@@ -92,7 +92,7 @@
     },
     {
       "name": "Time-to-finality",
-      "value": "25",
+      "value": "1500",
       "notes": "Zcash typically requires 10+ blocks for a transaction to be treated as secure. New blocks are mined roughly every 2.5 minutes on average, so 10 blocks take approximately 25 minutes (10 × 2.5 minutes per block).",
       "citations": [
         {
@@ -327,7 +327,7 @@
     },
     {
       "name": "Selective disclosure: viewing entity",
-      "value": ["User"],
+      "value": ["User", "Voluntary third-party disclosure"],
       "notes": "Zcash supports selective disclosure controlled by the user. The owner of a z-address can share its transaction details with trusted third parties via a view key–a key that grants read access but not spend authority over the address. This allows for selective disclosure where transactions are auditable but disclosure is under the participant's control. The user decides whether and with whom to share viewing keys, enabling voluntary disclosure for compliance, auditing, or tax purposes without protocol-level enforcement.",
       "citations": [
         {

--- a/project-evaluations/src/utils.ts
+++ b/project-evaluations/src/utils.ts
@@ -3,8 +3,28 @@ import type { Evaluation } from "./types.js";
 const NUMBER_OF_SECRETS_REGEX = /number of secrets/i;
 const PROJECT_README_PATH_REGEX = /subgraph\/src\/([^/]+)\/README\.md$/;
 
-/** Properties shown without a yes/no colour — the answer is contextual, not better or worse. */
-const NEUTRAL_TONE_PROPERTIES = new Set(["Plausible deniability"]);
+/** Formats seconds, or a "min-max" range, into readable parts, e.g. "9000" → "2 hours, 30 minutes", "15-30" → "15 seconds - 30 seconds". */
+function formatDuration(secondsValue: string): string {
+  const seconds = secondsValue.split("-").map(Number);
+  if (seconds.some(Number.isNaN)) return secondsValue;
+  return seconds.map(formatSeconds).join(" - ");
+}
+
+/** Formats a whole number of seconds into its non-zero parts, e.g. 9000 → "2 hours, 30 minutes". */
+function formatSeconds(totalSeconds: number): string {
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days} day${days === 1 ? "" : "s"}`);
+  if (hours > 0) parts.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+  if (minutes > 0) parts.push(`${minutes} minute${minutes === 1 ? "" : "s"}`);
+  if (seconds > 0) parts.push(`${seconds} second${seconds === 1 ? "" : "s"}`);
+
+  return parts.join(", ") || "0 seconds";
+}
 
 interface IValueForParams {
   evaluations: Evaluation;
@@ -26,7 +46,15 @@ export function valueFor({ evaluations, propertyName }: IValueForParams): IValue
     return { value: "—", notes: "", url: "", needsResearchReview: "" };
   }
 
-  const value = Array.isArray(property.value) ? property.value.join(", ") : property.value;
+  let value = Array.isArray(property.value) ? property.value.join(", ") : property.value;
+
+  const nonDurationValues = new Set(["", "N/A", "Underlying chain"]);
+  const timeProperties = new Set(["Time-to-finality", "Deposit time", "Withdraw time"]);
+
+  const timeRequiresFormat = timeProperties.has(propertyName) && !nonDurationValues.has(value);
+  if (timeRequiresFormat) {
+    value = formatDuration(value);
+  }
 
   return {
     value: value || "—",
@@ -48,7 +76,8 @@ type CellTone = "yes" | "no" | "warn" | "";
  * @dev it is currently used to mark as yellow if number of secrets is 2 or greater
  */
 export function cellTone({ value, propertyName }: ICellToneParams): CellTone {
-  if (NEUTRAL_TONE_PROPERTIES.has(propertyName)) {
+  const neutralToneProperties = new Set(["Plausible deniability"]);
+  if (neutralToneProperties.has(propertyName)) {
     return "";
   }
 


### PR DESCRIPTION
# What this PR does

- normalise time values so all values are in seconds and get formatted to a human readable version. 3600 seconds is not immediately readable but 1 hour is.
- fix zcash bugs raised by zcash contributor feedback in W3PN Telegram
- update intmax finality value to latest from l2beat

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [x] I have supplied a PR description that explains what the PR does.
- [x] I have linked a github issue to the PR if one exists.
- [x] I ran and verified that all tests pass locally.
