### PR TITLE
fix(subgraph): veil cash syncing correctly

### DIFF
--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -7,7 +7,7 @@ The current versions of the deployed subgraphs are:
 - mainnet (private-transfers-mainnet-benchmarks): `v0.0.51`
 - sepolia (private-transfers-sepolia-benchmarks): `v0.0.2`
 - arbitrum (private-transfers-arbitrum-benchmarks): `v0.0.2`
-- base (private-transfers-base-benchmarks): `v0.0.9`
+- base (private-transfers-base-benchmarks): `v0.0.32`
 - scroll (private-transfers-scroll-benchmarks): `v0.0.3`
 - starknet (private-transfers-starknet-benchmarks): `<NOT_DEPLOYED_YET>`
 

--- a/subgraph/configuration/subgraph.base.yaml
+++ b/subgraph/configuration/subgraph.base.yaml
@@ -70,7 +70,7 @@ dataSources:
     source:
       address: "0x293dCda114533FF8f477271c5cA517209FFDEEe7"
       abi: VeilETHPool
-      startBlock: 37986023
+      startBlock: 31475622
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9

--- a/subgraph/src/veil-cash/README.md
+++ b/subgraph/src/veil-cash/README.md
@@ -30,12 +30,4 @@
 
 ## Withdraw
 
-1. User [withdraws](https://basescan.org/tx/0xd1ab273564036293c18791266223f51882ed3e2c249d32450da73fefd975c2da) funds from the shielded pool contract. The transaction emits `Withdraw(address indexed,uint256)` from the Wrapped ETH (WETH) contract with the src (first parameter) being the shielded pool contract address and the value (second parameter) being the amount withdrawn.
-
-# Important notes
-
-We are having some issues when syncing the subgraph, specifically we have found the following transactions that are throwing Out of Bounds errors:
-
-- [Contract ETHPool emits `NewNullifier(bytes32)` at block 31476880](https://basescan.org/tx/0xccf77764e49f82bf7450986d100bd218588067ebb6fca1557f63032c256e9d2a)
-- [Contract ETHPool emits `NewNullifier(bytes32)` at block 37986022](https://basescan.org/tx/0x03847ced58eaa28fbb67c9ce2933013c3fdd5fa0fc93d9583b6b622280200ae9)
-- [Contract ETHPool emits `NewNullifier(bytes32)` at block 38025331](https://basescan.org/tx/0xc1f0971f0da2a08917e4fc88db3cf3a82ed316b78fc75fb604f6a1ac76d699d6)
+1. User [withdraws](https://basescan.org/tx/0xd1ab273564036293c18791266223f51882ed3e2c249d32450da73fefd975c2da) funds from the shielded pool contract. The transaction emits `Withdrawal(address indexed,uint256)` from the Wrapped ETH (WETH) contract with the src (first parameter) being the shielded pool contract address and the value (second parameter) being the amount withdrawn.

--- a/subgraph/src/veil-cash/utils.ts
+++ b/subgraph/src/veil-cash/utils.ts
@@ -1,0 +1,20 @@
+import { ethereum, ByteArray, crypto as graphCrypto } from "@graphprotocol/graph-ts";
+
+const WITHDRAW_TOPIC = graphCrypto.keccak256(ByteArray.fromUTF8("Withdrawal(address,uint256)"));
+const NUMBER_OF_TOPICS_IN_WITHDRAW_EVENT = 2; // topics: signature, src. data: wad (not indexed)
+
+export function getWithdrawalEvent(logs: ethereum.Log[]): ethereum.Log | null {
+  for (let i = 0; i < logs.length; i += 1) {
+    const log = logs[i];
+
+    if (log.topics.length === NUMBER_OF_TOPICS_IN_WITHDRAW_EVENT) {
+      if (log.topics[0].equals(WITHDRAW_TOPIC)) {
+        return log;
+      }
+
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/subgraph/src/veil-cash/veil-eth-pool.ts
+++ b/subgraph/src/veil-cash/veil-eth-pool.ts
@@ -1,55 +1,15 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { BigInt } from "@graphprotocol/graph-ts";
 
 import {
-  VeilCashOperationStats,
-  VeilCashProtocolStats,
   VeilCashTransfer,
   VeilCashTransferStats,
+  VeilCashWithdraw,
+  VeilCashWithdrawStats,
 } from "../../generated/schema";
 import { NewNullifier as NewNullifierEvent } from "../../generated/VeilETHPool/VeilETHPool";
 
-export const VEIL_ETH_POOL_ADDRESS = Address.fromString("0x293dcda114533ff8f477271c5ca517209ffdeee7");
-
-export function createOrLoadProtocolStats(): VeilCashProtocolStats {
-  const id = "veil-cash-protocol-stats";
-  let stats = VeilCashProtocolStats.load(id);
-
-  if (stats === null) {
-    stats = new VeilCashProtocolStats(id);
-    stats.totalTxCount = BigInt.zero();
-    stats.totalGasUsed = BigInt.zero();
-
-    const queueStats = new VeilCashOperationStats(`${id}-deposit-queued`);
-    const acceptedStats = new VeilCashOperationStats(`${id}-deposit-accepted`);
-    const transferStats = new VeilCashOperationStats(`${id}-transfer`);
-    const withdrawStats = new VeilCashOperationStats(`${id}-withdraw`);
-
-    stats.depositQueued = queueStats.id;
-    stats.depositAccepted = acceptedStats.id;
-    stats.transfer = transferStats.id;
-    stats.withdraw = withdrawStats.id;
-
-    queueStats.totalCount = BigInt.zero();
-    queueStats.totalGasUsed = BigInt.zero();
-
-    acceptedStats.totalCount = BigInt.zero();
-    acceptedStats.totalGasUsed = BigInt.zero();
-
-    transferStats.totalCount = BigInt.zero();
-    transferStats.totalGasUsed = BigInt.zero();
-
-    withdrawStats.totalCount = BigInt.zero();
-    withdrawStats.totalGasUsed = BigInt.zero();
-
-    queueStats.save();
-    acceptedStats.save();
-    transferStats.save();
-    withdrawStats.save();
-    stats.save();
-  }
-
-  return stats;
-}
+import { getWithdrawalEvent } from "./utils";
+import { createOrLoadProtocolStats, saveOperationStats, saveProtocolStats } from "./veil-eth-queue-v3";
 
 function createOrLoadTransferStats(operationStatsId: string): VeilCashTransferStats {
   const id = "veil-cash-transfer-native-eth";
@@ -67,12 +27,66 @@ function createOrLoadTransferStats(operationStatsId: string): VeilCashTransferSt
   return stats;
 }
 
+function createOrLoadWithdrawStats(operationStatsId: string): VeilCashWithdrawStats {
+  const id = "veil-cash-withdraw-native-eth";
+  let stats = VeilCashWithdrawStats.load(id);
+
+  if (stats === null) {
+    stats = new VeilCashWithdrawStats(id);
+    stats.totalCount = BigInt.zero();
+    stats.totalGasUsed = BigInt.zero();
+    stats.totalValue = BigInt.zero();
+    stats.operationStats = operationStatsId;
+    stats.save();
+  }
+
+  return stats;
+}
+
 export function handleNewNullifier(event: NewNullifierEvent): void {
   const txId = event.transaction.hash.toHex();
+  const stats = createOrLoadProtocolStats();
 
   const receipt = event.receipt;
 
   if (receipt === null) {
+    return;
+  }
+
+  const withdrawalEvent = getWithdrawalEvent(receipt.logs);
+
+  if (withdrawalEvent !== null) {
+    const existingWithdraw = VeilCashWithdraw.load(txId);
+
+    if (existingWithdraw !== null) {
+      return;
+    }
+
+    const withdraw = new VeilCashWithdraw(txId);
+    const value = BigInt.fromUnsignedBytes(withdrawalEvent.data);
+
+    withdraw.blockNumber = event.block.number;
+    withdraw.timestamp = event.block.timestamp;
+    withdraw.txHash = event.transaction.hash;
+    withdraw.value = value;
+    withdraw.gasUsed = receipt.gasUsed;
+    withdraw.gasPrice = event.transaction.gasPrice;
+
+    withdraw.save();
+
+    const withdrawOperationId = stats.withdraw;
+
+    saveProtocolStats(event);
+    saveOperationStats(withdrawOperationId, event);
+
+    const withdrawStats = createOrLoadWithdrawStats(withdrawOperationId);
+
+    withdrawStats.totalCount = withdrawStats.totalCount.plus(BigInt.fromI32(1));
+    withdrawStats.totalGasUsed = withdrawStats.totalGasUsed.plus(receipt.gasUsed);
+    withdrawStats.totalValue = withdrawStats.totalValue.plus(value);
+    withdrawStats.operationStats = withdrawOperationId;
+    withdrawStats.save();
+
     return;
   }
 
@@ -92,23 +106,15 @@ export function handleNewNullifier(event: NewNullifierEvent): void {
 
   transfer.save();
 
-  const stats = createOrLoadProtocolStats();
+  const transferOperationId = stats.transfer;
 
-  stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
-  stats.totalGasUsed = stats.totalGasUsed.plus(receipt.gasUsed);
-  stats.save();
+  saveProtocolStats(event);
+  saveOperationStats(transferOperationId, event);
 
-  const operationStats = VeilCashOperationStats.load(stats.transfer);
-
-  if (operationStats !== null) {
-    operationStats.totalCount = operationStats.totalCount.plus(BigInt.fromI32(1));
-    operationStats.totalGasUsed = operationStats.totalGasUsed.plus(receipt.gasUsed);
-    operationStats.save();
-  }
-
-  const transferStats = createOrLoadTransferStats(stats.transfer);
+  const transferStats = createOrLoadTransferStats(transferOperationId);
 
   transferStats.totalCount = transferStats.totalCount.plus(BigInt.fromI32(1));
   transferStats.totalGasUsed = transferStats.totalGasUsed.plus(receipt.gasUsed);
+  transferStats.operationStats = transferOperationId;
   transferStats.save();
 }

--- a/subgraph/src/veil-cash/veil-eth-queue-v3.ts
+++ b/subgraph/src/veil-cash/veil-eth-queue-v3.ts
@@ -13,7 +13,7 @@ import {
   DepositQueued as DepositQueuedEvent,
 } from "../../generated/VeilETHQueueV3/VeilETHQueueV3";
 
-function createOrLoadProtocolStats(): VeilCashProtocolStats {
+export function createOrLoadProtocolStats(): VeilCashProtocolStats {
   const id = "veil-cash-protocol-stats";
   let stats = VeilCashProtocolStats.load(id);
 
@@ -54,7 +54,7 @@ function createOrLoadProtocolStats(): VeilCashProtocolStats {
   return stats;
 }
 
-function saveProtocolStats(event: ethereum.Event): void {
+export function saveProtocolStats(event: ethereum.Event): void {
   const stats = createOrLoadProtocolStats();
 
   stats.totalTxCount = stats.totalTxCount.plus(BigInt.fromI32(1));
@@ -98,7 +98,7 @@ function createOrLoadDepositAcceptedStats(operationStatsId: string): VeilCashDep
   return stats;
 }
 
-function saveOperationStats(operationId: string, event: ethereum.Event): void {
+export function saveOperationStats(operationId: string, event: ethereum.Event): void {
   const operationStats = VeilCashOperationStats.load(operationId);
 
   if (operationStats !== null) {

--- a/subgraph/tests/veil-cash/utils.ts
+++ b/subgraph/tests/veil-cash/utils.ts
@@ -1,11 +1,13 @@
-import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, ByteArray, Bytes, crypto as graphCrypto, ethereum } from "@graphprotocol/graph-ts";
 import { newMockEvent } from "matchstick-as";
 
 import { NewNullifier } from "../../generated/VeilETHPool/VeilETHPool";
 import { DepositAccepted, DepositQueued } from "../../generated/VeilETHQueueV3/VeilETHQueueV3";
 
 export const PROTOCOL_STATS_ID = "veil-cash-protocol-stats";
-export const VEIL_ETH_POOL_ADDRESS = Address.fromString("0x293dcda114533ff8f477271c5ca517209ffdeee7");
+
+export const WITHDRAW_AMOUNT = Bytes.fromI32(4);
+const WITHDRAW_TOPIC = Bytes.fromUint8Array(graphCrypto.keccak256(ByteArray.fromUTF8("Withdrawal(address,uint256)")));
 
 export function createDepositQueuedEvent(
   nonce: BigInt,
@@ -54,6 +56,28 @@ export function createNewNullifierEvent(hash: Bytes): NewNullifier {
       ),
     ),
   );
+
+  return event;
+}
+
+export function createWithdrawalLog(): ethereum.Log {
+  const log = changetype<ethereum.Log>(newMockEvent());
+
+  log.topics = [WITHDRAW_TOPIC, Bytes.fromHexString("0x0000000000000000000000000000000000000000")];
+  log.data = WITHDRAW_AMOUNT;
+
+  return log;
+}
+
+export function createWithdrawEvent(hash: Bytes): NewNullifier {
+  const event = createNewNullifierEvent(hash);
+  const receipt = changetype<ethereum.TransactionReceipt>(newMockEvent());
+
+  receipt.logs = [createWithdrawalLog()];
+  receipt.gasUsed = BigInt.fromI32(1);
+
+  event.receipt = receipt;
+  event.transaction.gasPrice = BigInt.fromI32(1);
 
   return event;
 }

--- a/subgraph/tests/veil-cash/withdraw.test.ts
+++ b/subgraph/tests/veil-cash/withdraw.test.ts
@@ -1,0 +1,75 @@
+import { Bytes } from "@graphprotocol/graph-ts";
+import { assert, afterAll, beforeAll, clearStore, describe, test } from "matchstick-as/assembly/index";
+
+import { handleNewNullifier } from "../../src/veil-cash/veil-eth-pool";
+
+import { createWithdrawEvent, PROTOCOL_STATS_ID, WITHDRAW_AMOUNT } from "./utils";
+
+const OPERATION_ID = "withdraw";
+const WITHDRAW_STATS_ID = "veil-cash-withdraw-native-eth";
+const WITHDRAW_HASH = Bytes.fromHexString("0xa16081f360e3847006db660bae1c6d1b2e17ec2b");
+
+describe("VeilETHPool withdraw tests", () => {
+  describe("withdrawETH tx with nullifier", () => {
+    beforeAll(() => {
+      const event = createWithdrawEvent(WITHDRAW_HASH);
+
+      handleNewNullifier(event);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("VeilCashWithdraw created", () => {
+      assert.entityCount("VeilCashWithdraw", 1);
+    });
+
+    test("VeilCashWithdraw values stored correctly", () => {
+      const id = WITHDRAW_HASH.toHexString();
+
+      assert.fieldEquals("VeilCashWithdraw", id, "txHash", WITHDRAW_HASH.toHexString());
+      assert.fieldEquals("VeilCashWithdraw", id, "value", WITHDRAW_AMOUNT.toI32().toString());
+      assert.fieldEquals("VeilCashWithdraw", id, "gasUsed", "1");
+      assert.fieldEquals("VeilCashWithdraw", id, "gasPrice", "1");
+    });
+
+    test("Protocol stats updated", () => {
+      assert.fieldEquals("VeilCashProtocolStats", PROTOCOL_STATS_ID, "totalTxCount", "1");
+      assert.fieldEquals("VeilCashProtocolStats", PROTOCOL_STATS_ID, "totalGasUsed", "1");
+    });
+
+    test("Operation stats updated (withdraw)", () => {
+      assert.fieldEquals("VeilCashOperationStats", `${PROTOCOL_STATS_ID}-${OPERATION_ID}`, "totalCount", "1");
+      assert.fieldEquals("VeilCashOperationStats", `${PROTOCOL_STATS_ID}-${OPERATION_ID}`, "totalGasUsed", "1");
+    });
+
+    test("Withdraw stats updated", () => {
+      assert.fieldEquals("VeilCashWithdrawStats", WITHDRAW_STATS_ID, "totalCount", "1");
+      assert.fieldEquals("VeilCashWithdrawStats", WITHDRAW_STATS_ID, "totalGasUsed", "1");
+      assert.fieldEquals("VeilCashWithdrawStats", WITHDRAW_STATS_ID, "totalValue", WITHDRAW_AMOUNT.toI32().toString());
+    });
+  });
+
+  describe("multiple nullifiers in same tx", () => {
+    beforeAll(() => {
+      const event1 = createWithdrawEvent(WITHDRAW_HASH);
+      const event2 = createWithdrawEvent(WITHDRAW_HASH);
+
+      handleNewNullifier(event1);
+      handleNewNullifier(event2);
+    });
+
+    afterAll(() => {
+      clearStore();
+    });
+
+    test("Only one VeilCashWithdraw created", () => {
+      assert.entityCount("VeilCashWithdraw", 1);
+    });
+
+    test("Withdraw stats updated only once", () => {
+      assert.fieldEquals("VeilCashWithdrawStats", WITHDRAW_STATS_ID, "totalCount", "1");
+    });
+  });
+});


### PR DESCRIPTION
# What this PR does

- I found the issue with the Veil Cash syncing. Not really sure why but the error was caused due to not updating the `transferStats.operationStats = transferOperationId;` even though in the object creation we were specifying the value.
- I deployed version v0.0.32 to show/confirm these new modifications fix the Subgraph sync error.
- I added a small check logic to count Withdrawals in the same handler as Nullifiers. We were using the WETH handler before and we decided to pivot away from it.

Closes https://github.com/privacy-ethereum/private-transfers-benchmarks/issues/248

## Confirmation

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical error feel free to message the team.

- [X] I have supplied a PR description that explains what the PR does.
- [X] I have linked a github issue to the PR if one exists.
- [X] I ran and verified that all tests pass locally.
