### PR TITLE
fix(project-evaluations): repair lint drift from merged schema rename

### DIFF
--- a/project-evaluations/src/data/evaluations/aleo.json
+++ b/project-evaluations/src/data/evaluations/aleo.json
@@ -356,13 +356,13 @@
     },
     {
       "name": "Private State Scalability",
-      "value": "Infinity grow",
+      "value": "Per Transaction",
       "notes": "Aleo uses a single global commitment tree where record commitments are appended in-order and never pruned. The nullifier set similarly accumulates permanently to prevent double-spending, requiring full nodes to maintain the complete history. This represents an unbounded growth model where protocol-specific private state expands continuously with blockchain activity.",
       "url": "https://docs.aleo.org/specs/aleovm.pdf"
     },
     {
       "name": "Client-side indexing",
-      "value": "Always scanning",
+      "value": "Scanning",
       "notes": "Aleo requires always-on scanning for shielded transactions. Because shielded transactions reveal no metadata about sender or receiver, users must scan the chain using their view key. Every block must be trial-decrypted to check if any records were received. Shield wallet (developed by Provable, an Aleo Labs company) offers a privacy-preserving record scanning service that offloads this scanning while keeping the view key encrypted end-to-end.",
       "url": "https://docs.aleo.org/learn/advanced/record-scanning"
     },

--- a/project-evaluations/src/data/evaluations/anoma-pay.json
+++ b/project-evaluations/src/data/evaluations/anoma-pay.json
@@ -233,7 +233,7 @@
       "notes": "AnomaPay's public beta is live on Ethereum Mainnet and BNB Chain. Deposits are capped at $500 per user during the beta period, supporting payments in ETH, USDC, USDT, and XAN. The Anoma Protocol Adapter has been deployed more widely and for longer.",
       "citations": [
         {
-          "cited_text": "It is live on Ethereum Mainnet and BNB Chain",
+          "cited_text": "It is live on BNB Chain",
           "source": "https://docs.anoma.net/anoma-pay-introduction"
         },
         {


### PR DESCRIPTION
`pnpm run lint:evaluations` is failing on main after recent merges. Three issues, none protocol-new:

- **aleo.json** — `Private State Scalability` and `Client-side indexing` still carried the pre-rename values `Infinity grow` / `Always scanning`. The schema-rename PRs updated every other eval but missed aleo (merged via a separate external PR). Mapped to the current options: `Per Transaction` / `Scanning`.
- **anoma-pay.json** — the `Implementation maturity` `cited_text` ("It is live on Ethereum Mainnet and BNB Chain") no longer matched its source cache, which states only "It is live on BNB Chain". Aligned the span to the cache.

`pnpm run lint:evaluations` passes (55 files) after this change.

Note: anoma-pay's notes still mention Ethereum Mainnet, now uncited — left as-is since refreshing that eval's research is out of scope for a lint fix.